### PR TITLE
Add ability to apply two headers support tuning policies through experimtation

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -2,7 +2,7 @@ guard 'spork', :rspec_env => { 'RAILS_ENV' => 'test' } do
   watch('spec/spec_helper.rb') { :rspec }
 end
 
-guard 'rspec', :cli => "--color --drb", :keep_failed => true, :all_after_pass => true do
+guard 'rspec', :cli => "--color --drb", :keep_failed => true, :all_after_pass => true, :focus_on_failed => true do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch(%r{^app/controllers/(.+)\.rb$})     { |m| "spec/controllers/#{m[1]}_spec.rb" }

--- a/README.md
+++ b/README.md
@@ -131,6 +131,19 @@ and [Firefox CSP specification](https://wiki.mozilla.org/Security/CSP/Specificat
   # would produce the directive: "img-src https://* http://*;"
   # when over http, ignored for https requests
   :http_additions => {}
+
+  # If you have enforce => true, you can use the `experiments` block to
+  # also produce a report-only header. Values in this block override the
+  # parent config for the report-only, and leave the enforcing header
+  # unaltered. http_additions work the same way described above, but
+  # are added to your report-only header as expected.
+  :experimental => {
+    :script_src => 'self',
+    :img_src => 'https://mycdn.example.com',
+    :http_additions {
+      :img_src => 'http://mycdn.example.com'
+    }
+  }
 }
 ```
 

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -53,6 +53,10 @@ module SecureHeaders
 
       header = ContentSecurityPolicy.new(request, options)
       set_header(header.name, header.value)
+      if options && options[:experimental] && options[:enforce]
+        header = ContentSecurityPolicy.new(request, options, :experimental => true)
+        set_header(header.name, header.value)
+      end
     end
 
     def set_a_header(name, klass, options=nil)

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -221,5 +221,32 @@ describe SecureHeaders do
         subject.set_csp_header request
       end
     end
+
+    context "when using the experimental key" do
+      before(:each) do
+        stub_user_agent(USER_AGENTS[:chrome])
+        @opts = {
+          :enforce => true,
+          :default_src => 'self',
+          :script_src => 'https://mycdn.example.com',
+          :experimental => {
+            :script_src => 'self',
+          }
+        }
+      end
+
+      it "does not set the header in enforce mode if experimental is supplied, but enforce is disabled" do
+        opts = @opts.merge(:enforce => false)
+        should_assign_header(WEBKIT_CSP_HEADER_NAME + "-Report-Only", anything)
+        should_not_assign_header(WEBKIT_CSP_HEADER_NAME)
+        subject.set_csp_header request, opts
+      end
+
+      it "sets a header in enforce mode as well as report-only mode" do
+        should_assign_header(WEBKIT_CSP_HEADER_NAME, anything)
+        should_assign_header(WEBKIT_CSP_HEADER_NAME + "-Report-Only", anything)
+        subject.set_csp_header request, @opts
+      end
+    end
   end
 end


### PR DESCRIPTION
Let's say you currently use CSP in "enforce" mode. You think you can tighten your policy, but you don't want to break your site. In addition to the "enforce" header, apply a "report-only" header with a tighter policy.

Use the reports from the report-only to test what would be applied to the "enforce" header.
