### PR TITLE
Add Padrino Example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,46 @@ class Donkey < Sinatra::Application
 end
 ```
 
+### Using with Padrino
+
+You can use SecureHeaders for Padrino applications as well:
+
+In your `Gemfile`:
+
+```ruby
+  gem "secure-headers", :require => 'secure_headers'
+```
+
+then in your `app.rb` file you can:
+
+```ruby
+module Web
+  class App < Padrino::Application
+    include SecureHeaders
+
+    ::SecureHeaders::Configuration.configure do |config|
+      config.hsts                   = {:max_age => 99, :include_subdomains => true}
+      config.x_frame_options        = 'DENY'
+      config.x_content_type_options = "nosniff"
+      config.x_xss_protection       = {:value   => '1', :mode => false}
+      config.csp                    = {
+        :default_src => "https://* inline eval",
+        # ALWAYS supply a full URL for report URIs
+        :report_uri => 'https://example.com/uri-directive',
+        :img_src => "https://* data:",
+        :frame_src => "https://* http://*.twimg.com http://itunes.apple.com"
+      }
+    end
+
+    get '/' do
+      set_csp_header(request, nil)
+      render 'index'
+    end
+  end
+end
+```
+
+
 ## Authors
 
 * Neil Matatall [@ndm](https://twitter.com/ndm) - primary author.


### PR DESCRIPTION
This adds a [padrino](https://github.com/padrino/padrino-framework) application example in the README
