### PR TITLE
CSP endpoint only accepts post requests.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  match SecureHeaders::ContentSecurityPolicy::FF_CSP_ENDPOINT => "content_security_policy#scribe"
+  post SecureHeaders::ContentSecurityPolicy::FF_CSP_ENDPOINT => "content_security_policy#scribe"
 end


### PR DESCRIPTION
This fixes compatibility with Rails 4 where the `match` routing option is no longer available.

The W3C spec says that the reports should always be POST requests.

http://www.w3.org/TR/CSP/#report-uri
