### PR TITLE
Append data: to the img-src directive automatically

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,6 @@ group :test do
   gem 'growl'
   gem 'rb-fsevent'
   gem 'simplecov'
+  gem 'debugger', :platform => :ruby_19
+  gem 'ruby-debug', :platform => :ruby_18
 end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -263,6 +263,12 @@ module SecureHeaders
 
     def generic_directives(config)
       header_value = ''
+      if config[:img_src]
+        config[:img_src] = config[:img_src] + ['data:'] unless config[:img_src].include?('data:')
+      else
+        config[:img_src] = ['data:']
+      end
+
       config.keys.sort_by{|k| k.to_s}.each do |k| # ensure consistent ordering
         header_value += "#{symbol_to_hyphen_case(k)} #{config[k].join(" ")}; "
       end


### PR DESCRIPTION
Since <img src=data:....> is safe (besides crazy browser exploits) so let's whitelist that by default.
