### PR TITLE
rails 3.0.x support

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -283,11 +283,11 @@ module SecureHeaders
     def parse_request request
       @browser = Brwsr::Browser.new(:ua => request.env['HTTP_USER_AGENT'])
       @ssl_request = request.ssl?
-      @request_uri = if defined? ActionDispatch::Request
-        # rails 3
+      @request_uri = if request.respond_to?(:original_url)
+        # rails 3.1+
         request.original_url
       else
-        # rails 2
+        # rails 2/3.0
         request.url
       end
     end

--- a/lib/secure_headers/railtie.rb
+++ b/lib/secure_headers/railtie.rb
@@ -2,7 +2,7 @@
 if defined?(Rails::Railtie)
   module SecureHeaders
     class Railtie < Rails::Engine
-      isolate_namespace ::SecureHeaders
+      isolate_namespace ::SecureHeaders if defined? isolate_namespace # rails 3.0
       ActionController::Base.send :include, ::SecureHeaders
     end
   end


### PR DESCRIPTION
don't isolate name space, use old request API
