### PR TITLE
Allow HSTS max_age values to be a string or an integer

### DIFF
--- a/lib/secure_headers/headers/strict_transport_security.rb
+++ b/lib/secure_headers/headers/strict_transport_security.rb
@@ -41,7 +41,7 @@ module SecureHeaders
       if @config.is_a? Hash
         if !@config[:max_age]
           raise STSBuildError.new("No max-age was supplied.")
-        elsif @config[:max_age] !~ /\A\d+\z/
+        elsif @config[:max_age].to_s !~ /\A\d+\z/
           raise STSBuildError.new("max-age must be a number. #{@config[:max_age]} was supplied.")
         end
       else

--- a/spec/lib/secure_headers/headers/strict_transport_security_spec.rb
+++ b/spec/lib/secure_headers/headers/strict_transport_security_spec.rb
@@ -28,6 +28,18 @@ module SecureHeaders
 
       context "with an invalid configuration" do
         context "with a hash argument" do
+          it "should allow string values for max-age" do
+            lambda {
+              StrictTransportSecurity.new(:max_age => '1234')
+            }.should_not raise_error
+          end
+
+          it "should allow integer values for max-age" do
+            lambda {
+              StrictTransportSecurity.new(:max_age => 1234)
+            }.should_not raise_error
+          end
+
           it "raises an exception with an invalid max-age" do
             lambda {
               StrictTransportSecurity.new(:max_age => 'abc123')


### PR DESCRIPTION
I ran into a problem where I was using 1.year.to_i for my max_age, yet STSBuildError kept throwing on me. Similar to how X-XSS-Protection values were fixed, change HSTS max_age to allow strings or integers.
