### PR TITLE
Script-nonce support

### DIFF
--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -72,10 +72,10 @@ module SecureHeaders
       options = self.class.options_for :csp, options
       return if options == false
 
-      header = ContentSecurityPolicy.new(options, :request => request)
+      header = ContentSecurityPolicy.new(options, :request => request, :controller => self)
       set_header(header.name, header.value)
       if options && options[:experimental] && options[:enforce]
-        header = ContentSecurityPolicy.new(options, :experimental => true, :request => request)
+        header = ContentSecurityPolicy.new(options, :experimental => true, :request => request, :controller => self)
         set_header(header.name, header.value)
       end
     end


### PR DESCRIPTION
An example use would be:

``` ruby
:script_nonce => lambda { params[:script_nonce] = SecureRandom.hex(16) },
```

and then in your Haml (if you are so inclined):

``` haml
%script{type: "text/javascript", nonce: params[:script_nonce]}
```

Minor downside, as far as I know no browser yet supports this for actual enforcement though WebKit itself added support [last year](https://bugs.webkit.org/show_bug.cgi?id=89577). The spec is designed for transparent upgrade though, so you can add it now and benefit silently once it is supported.
