### PR TITLE
fix a typo and change formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ By default, it will set all of the headers listed in the options section below u
 
 Use the standard `skip_before_filter :filter_name, options` mechanism. e.g. `skip_before_filter :set_csp_header, :only => :tinymce_page`
 
-The following methods are going to be called, unles they are provided in a `skip_before_filter` block.
+The following methods are going to be called, unless they are provided in a `skip_before_filter` block.
 
 * `:set_csp_header`
 * `:set_hsts_header`
@@ -53,10 +53,10 @@ The following methods are going to be called, unles they are provided in a `skip
 
 This gem makes a few assumptions about how you will use some features.  For example:
 
-* It adds 'chrome-extension:' to your CSP directives by default.  This helps drastically reduce the amount of reports, but you can also disable this feature by supplying :disable_chrome_extension => true.
-* It fills any blank directives with the value in :default_src  Getting a default\-src report is pretty useless.  This way, you will always know what type of violation occurred. You can disable this feature by supplying :disable_fill_missing => true.
+* It adds 'chrome-extension:' to your CSP directives by default.  This helps drastically reduce the amount of reports, but you can also disable this feature by supplying `:disable_chrome_extension => true`.
+* It fills any blank directives with the value in `:default_src`  Getting a default\-src report is pretty useless.  This way, you will always know what type of violation occurred. You can disable this feature by supplying `:disable_fill_missing => true`.
 * It copies the connect\-src value to xhr\-src for AJAX requests when using Firefox.
-* Firefox does not support cross\-origin CSP reports.  If we are using Firefox, AND the value for :report_uri does not satisfy the same\-origin requirements, we will instead forward to an internal endpoint (`FF_CSP_ENDPOINT`).  This is also the case if :report_uri only contains a path, which we assume will be cross host. This endpoint will in turn forward the request to the value in :forward_endpoint without restriction. More information can be found in the "Note on Firefox handling of CSP" section.
+* Firefox does not support cross\-origin CSP reports.  If we are using Firefox, AND the value for `:report_uri` does not satisfy the same\-origin requirements, we will instead forward to an internal endpoint (`FF_CSP_ENDPOINT`).  This is also the case if `:report_uri` only contains a path, which we assume will be cross host. This endpoint will in turn forward the request to the value in `:forward_endpoint` without restriction. More information can be found in the "Note on Firefox handling of CSP" section.
 
 
 ## Configuration


### PR DESCRIPTION
I added a missing "s" and I added some inline code tags to the "Automagic" section
