### PR TITLE
A few changes related to XFO, a typo fix, and spec test description improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The gem will automatically apply several headers that are related to security.  This includes:
 - Content Security Policy (CSP) - Helps detect/prevent XSS, mixed-content, and other classes of attack.  [CSP 1.1 Specification](https://dvcs.w3.org/hg/content-security-policy/raw-file/tip/csp-specification.dev.html)
 - HTTP Strict Transport Security (HSTS) - Ensures the browser never visits the http version of a website. Protects from SSLStrip/Firesheep attacks.  [HSTS Specification](https://tools.ietf.org/html/rfc6797)
-- X-Frame-Options (XFO) - Prevents your content from being framed and potentially clickjacked. [X-Frame-Options draft](https://tools.ietf.org/html/draft-ietf-websec-x-frame-options-00)
+- X-Frame-Options (XFO) - Prevents your content from being framed and potentially clickjacked. [X-Frame-Options draft](https://tools.ietf.org/html/draft-ietf-websec-x-frame-options-02)
 - X-XSS-Protection - [Cross site scripting heuristic filter for IE/Chrome](http://msdn.microsoft.com/en-us/library/dd565647\(v=vs.85\).aspx)
 - X-Content-Type-Options - [Prevent content type sniffing](http://msdn.microsoft.com/en-us/library/ie/gg622941\(v=vs.85\).aspx)
 
@@ -101,7 +101,7 @@ header will be constructed using the supplied options.
 ### Widely supported
 
 ```ruby
-:hsts             => {:max_age => 631138519, :include_subdomain => true}
+:hsts             => {:max_age => 631138519, :include_subdomains => true}
 :x_frame_options  => {:value => 'SAMEORIGIN'}
 :x_xss_protection => {:value => 1, :mode => false}  # set the :mode option to 'block' to enforce the browser's xss filter
 ```

--- a/fixtures/rails_3_2_12/config/initializers/secure_headers.rb
+++ b/fixtures/rails_3_2_12/config/initializers/secure_headers.rb
@@ -2,7 +2,7 @@
   config.hsts = { :max_age => 10.years.to_i.to_s, :include_subdomains => false }
   config.x_frame_options = 'SAMEORIGIN'
   config.x_content_type_options = "nosniff"
-  config.x_xss_protection = {:value => 1, :mode => 'BLOCK'}
+  config.x_xss_protection = {:value => 1, :mode => 'block'}
   csp = {
     :default_src => "self",
     :disable_chrome_extension => true,

--- a/fixtures/rails_3_2_12/spec/controllers/other_things_controller_spec.rb
+++ b/fixtures/rails_3_2_12/spec/controllers/other_things_controller_spec.rb
@@ -7,14 +7,14 @@ describe OtherThingsController do
       request.env['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5'
     end
 
-    it "sets the X-XSS-PROTECTION header" do
+    it "sets the X-XSS-Protection header" do
       get :index
-      response.headers['X-XSS-Protection'].should == '1; mode=BLOCK'
+      response.headers['X-XSS-Protection'].should == '1; mode=block'
     end
 
-    it "sets the X-FRAME-OPTIONS header" do
+    it "sets the X-Frame-Options header" do
       get :index
-      response.headers['X-FRAME-OPTIONS'].should == 'SAMEORIGIN'
+      response.headers['X-Frame-Options'].should == 'SAMEORIGIN'
     end
 
     it "sets the X-WebKit-CSP header" do
@@ -23,14 +23,14 @@ describe OtherThingsController do
     end
 
     #mock ssl
-    it "sets the STRICT-TRANSPORT-SECURITY header" do
+    it "sets the Strict-Transport-Security header" do
       request.env['HTTPS'] = 'on'
       get :index
       response.headers['Strict-Transport-Security'].should == "max-age=315576000"
     end
 
     context "using IE" do
-      it "sets the X-CONTENT-TYPE-OPTIONS header" do
+      it "sets the X-Content-Type-Options header" do
         request.env['HTTP_USER_AGENT'] = "Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0"
         get :index
         response.headers['X-Content-Type-Options'].should == "nosniff"

--- a/fixtures/rails_3_2_12/spec/controllers/things_controller_spec.rb
+++ b/fixtures/rails_3_2_12/spec/controllers/things_controller_spec.rb
@@ -11,14 +11,14 @@ describe ThingsController do
         request.env['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5'
     end
 
-    it "sets the X-XSS-PROTECTION header" do
+    it "sets the X-XSS-Protection header" do
       get :index
-      response.headers['X-XSS-Protection'].should == '1; mode=BLOCK'
+      response.headers['X-XSS-Protection'].should == '1; mode=block'
     end
 
-    it "sets the X-FRAME-OPTIONS header" do
+    it "sets the X-Frame-Options header" do
       get :index
-      response.headers['X-FRAME-OPTIONS'].should == 'SAMEORIGIN'
+      response.headers['X-Frame-Options'].should == 'SAMEORIGIN'
     end
 
     it "sets the X-WebKit-CSP header" do
@@ -27,14 +27,14 @@ describe ThingsController do
     end
 
     #mock ssl
-    it "sets the STRICT-TRANSPORT-SECURITY header" do
+    it "sets the Strict-Transport-Security header" do
       request.env['HTTPS'] = 'on'
       get :index
       response.headers['Strict-Transport-Security'].should == "max-age=315576000"
     end
 
     context "using IE" do
-      it "sets the X-CONTENT-TYPE-OPTIONS header" do
+      it "sets the X-Content-Type-Options header" do
         request.env['HTTP_USER_AGENT'] = "Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0"
         get :index
         response.headers['X-Content-Type-Options'].should == "nosniff"

--- a/fixtures/rails_3_2_12_no_init/spec/controllers/other_things_controller_spec.rb
+++ b/fixtures/rails_3_2_12_no_init/spec/controllers/other_things_controller_spec.rb
@@ -7,14 +7,14 @@ describe OtherThingsController do
       request.env['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5'
     end
 
-    it "sets the X-XSS-PROTECTION header" do
+    it "sets the X-XSS-Protection header" do
       get :index
       response.headers['X-XSS-Protection'].should == SecureHeaders::XXssProtection::Constants::DEFAULT_VALUE
     end
 
-    it "sets the X-FRAME-OPTIONS header" do
+    it "sets the X-Frame-Options header" do
       get :index
-      response.headers['X-FRAME-OPTIONS'].should == SecureHeaders::XFrameOptions::Constants::DEFAULT_VALUE
+      response.headers['X-Frame-Options'].should == SecureHeaders::XFrameOptions::Constants::DEFAULT_VALUE
     end
 
     it "sets the X-WebKit-CSP header" do
@@ -23,14 +23,14 @@ describe OtherThingsController do
     end
 
     #mock ssl
-    it "sets the STRICT-TRANSPORT-SECURITY header" do
+    it "sets the Strict-Transport-Security header" do
       request.env['HTTPS'] = 'on'
       get :index
       response.headers['Strict-Transport-Security'].should == SecureHeaders::StrictTransportSecurity::Constants::DEFAULT_VALUE
     end
 
     context "using IE" do
-      it "sets the X-CONTENT-TYPE-OPTIONS header" do
+      it "sets the X-Content-Type-Options header" do
         request.env['HTTP_USER_AGENT'] = "Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0"
         get :index
         response.headers['X-Content-Type-Options'].should == "nosniff"

--- a/fixtures/rails_3_2_12_no_init/spec/controllers/things_controller_spec.rb
+++ b/fixtures/rails_3_2_12_no_init/spec/controllers/things_controller_spec.rb
@@ -11,14 +11,14 @@ describe ThingsController do
         request.env['HTTP_USER_AGENT'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.56 Safari/536.5'
     end
 
-    it "sets the X-XSS-PROTECTION header" do
+    it "sets the X-XSS-Protection header" do
       get :index
       response.headers['X-XSS-Protection'].should == SecureHeaders::XXssProtection::Constants::DEFAULT_VALUE
     end
 
-    it "sets the X-FRAME-OPTIONS header" do
+    it "sets the X-Frame-Options header" do
       get :index
-      response.headers['X-FRAME-OPTIONS'].should == SecureHeaders::XFrameOptions::Constants::DEFAULT_VALUE
+      response.headers['X-Frame-Options'].should == SecureHeaders::XFrameOptions::Constants::DEFAULT_VALUE
     end
 
     it "sets the X-WebKit-CSP header" do
@@ -27,14 +27,14 @@ describe ThingsController do
     end
 
     #mock ssl
-    it "sets the STRICT-TRANSPORT-SECURITY header" do
+    it "sets the Strict-Transport-Security header" do
       request.env['HTTPS'] = 'on'
       get :index
       response.headers['Strict-Transport-Security'].should == SecureHeaders::StrictTransportSecurity::Constants::DEFAULT_VALUE
     end
 
     context "using IE" do
-      it "sets the X-CONTENT-TYPE-OPTIONS header" do
+      it "sets the X-Content-Type-Options header" do
         request.env['HTTP_USER_AGENT'] = "Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0"
         get :index
         response.headers['X-Content-Type-Options'].should == "nosniff"

--- a/lib/secure_headers/headers/x_frame_options.rb
+++ b/lib/secure_headers/headers/x_frame_options.rb
@@ -2,9 +2,9 @@ module SecureHeaders
   class XFOBuildError < StandardError; end
   class XFrameOptions
     module Constants
-      XFO_HEADER_NAME = "X-FRAME-OPTIONS"
+      XFO_HEADER_NAME = "X-Frame-Options"
       DEFAULT_VALUE = 'SAMEORIGIN'
-      VALID_XFO_HEADER = /\A(SAMEORIGIN\z|DENY\z|ALLOW-FROM:)/i
+      VALID_XFO_HEADER = /\A(SAMEORIGIN\z|DENY\z|ALLOW-FROM[:\s])/i
     end
     include Constants
 

--- a/spec/lib/secure_headers/headers/x_frame_options_spec.rb
+++ b/spec/lib/secure_headers/headers/x_frame_options_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module SecureHeaders
   describe XFrameOptions do
-    specify{ XFrameOptions.new.name.should == "X-FRAME-OPTIONS" }
+    specify{ XFrameOptions.new.name.should == "X-Frame-Options" }
 
     describe "#value" do
       specify { XFrameOptions.new.value.should == XFrameOptions::Constants::DEFAULT_VALUE}

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -96,29 +96,29 @@ describe SecureHeaders do
       end
     end
 
-    it "does not set the X-Content-Type-Options when disabled" do
+    it "does not set the X-Content-Type-Options header if disabled" do
       stub_user_agent(USER_AGENTS[:ie])
       should_not_assign_header(X_CONTENT_TYPE_OPTIONS_HEADER_NAME)
       subject.set_x_content_type_options_header(false)
     end
 
-    it "does not set the X-XSS-PROTECTION when disabled" do
+    it "does not set the X-XSS-Protection header if disabled" do
       stub_user_agent(USER_AGENTS[:ie])
       should_not_assign_header(X_XSS_PROTECTION_HEADER_NAME)
       subject.set_x_xss_protection_header(false)
     end
 
-    it "does not set the X-FRAME-OPTIONS header if disabled" do
+    it "does not set the X-Frame-Options header if disabled" do
       should_not_assign_header(XFO_HEADER_NAME)
       subject.set_x_frame_options_header(false)
     end
 
-    it "does not set the hsts header if disabled" do
+    it "does not set the HSTS header if disabled" do
       should_not_assign_header(HSTS_HEADER_NAME)
       subject.set_hsts_header(false)
     end
 
-    it "does not set the hsts header the request is over HTTP" do
+    it "does not set the HSTS header if request is over HTTP" do
       subject.stub_chain(:request, :ssl?).and_return(false)
       should_not_assign_header(HSTS_HEADER_NAME)
       subject.set_hsts_header({:include_subdomains => true})
@@ -155,12 +155,12 @@ describe SecureHeaders do
   end
 
   describe "#set_x_frame_options_header" do
-    it "sets the X-FRAME-OPTIONS header" do
+    it "sets the X-Frame-Options header" do
       should_assign_header(XFO_HEADER_NAME, SecureHeaders::XFrameOptions::Constants::DEFAULT_VALUE)
       subject.set_x_frame_options_header
     end
 
-    it "allows a custom X-FRAME-OPTIONS header" do
+    it "allows a custom X-Frame-Options header" do
       should_assign_header(XFO_HEADER_NAME, "DENY")
       subject.set_x_frame_options_header(:value => 'DENY')
     end
@@ -172,12 +172,12 @@ describe SecureHeaders do
     end
 
     describe "#set_x_xss_protection" do
-      it "sets the XSS protection header" do
+      it "sets the X-XSS-Protection header" do
         should_assign_header(X_XSS_PROTECTION_HEADER_NAME, '1')
         subject.set_x_xss_protection_header
       end
 
-      it "sets a custom X-XSS-PROTECTION header" do
+      it "sets a custom X-XSS-Protection header" do
         should_assign_header(X_XSS_PROTECTION_HEADER_NAME, '0')
         subject.set_x_xss_protection_header("0")
       end
@@ -189,7 +189,7 @@ describe SecureHeaders do
     end
 
     describe "#set_x_content_type_options" do
-      it "sets the X-Content-Type-Options" do
+      it "sets the X-Content-Type-Options header" do
         should_assign_header(X_CONTENT_TYPE_OPTIONS_HEADER_NAME, 'nosniff')
         subject.set_x_content_type_options_header
       end


### PR DESCRIPTION
- Two changes to X-Frame-Options, as per current spec draft
  (https://tools.ietf.org/html/draft-ietf-websec-x-frame-options-02)
  - Use 'X-Frame-Options' instead of 'X-FRAME-OPTIONS'
  - Make the colon after X-Frame-Options: ALLOW-FROM optional
- Fix typo in README for 'widely supported' config
- Improve spec test descriptions
