### PR TITLE
Send X-Content-Type-Options header to Chrome users as well (not just IE) and improve tests

### DIFF
--- a/fixtures/rails_3_2_12/spec/controllers/other_things_controller_spec.rb
+++ b/fixtures/rails_3_2_12/spec/controllers/other_things_controller_spec.rb
@@ -29,6 +29,11 @@ describe OtherThingsController do
       response.headers['Strict-Transport-Security'].should == "max-age=315576000"
     end
 
+    it "sets the X-Content-Type-Options header" do
+      get :index
+      response.headers['X-Content-Type-Options'].should == "nosniff"
+    end
+
     context "using IE" do
       it "sets the X-Content-Type-Options header" do
         request.env['HTTP_USER_AGENT'] = "Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0"

--- a/fixtures/rails_3_2_12/spec/controllers/things_controller_spec.rb
+++ b/fixtures/rails_3_2_12/spec/controllers/things_controller_spec.rb
@@ -33,6 +33,11 @@ describe ThingsController do
       response.headers['Strict-Transport-Security'].should == "max-age=315576000"
     end
 
+    it "sets the X-Content-Type-Options header" do
+      get :index
+      response.headers['X-Content-Type-Options'].should == "nosniff"
+    end
+
     context "using IE" do
       it "sets the X-Content-Type-Options header" do
         request.env['HTTP_USER_AGENT'] = "Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0"

--- a/fixtures/rails_3_2_12_no_init/spec/controllers/other_things_controller_spec.rb
+++ b/fixtures/rails_3_2_12_no_init/spec/controllers/other_things_controller_spec.rb
@@ -29,11 +29,16 @@ describe OtherThingsController do
       response.headers['Strict-Transport-Security'].should == SecureHeaders::StrictTransportSecurity::Constants::DEFAULT_VALUE
     end
 
+    it "sets the X-Content-Type-Options header" do
+      get :index
+      response.headers['X-Content-Type-Options'].should == SecureHeaders::XContentTypeOptions::Constants::DEFAULT_VALUE
+    end
+
     context "using IE" do
       it "sets the X-Content-Type-Options header" do
         request.env['HTTP_USER_AGENT'] = "Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0"
         get :index
-        response.headers['X-Content-Type-Options'].should == "nosniff"
+        response.headers['X-Content-Type-Options'].should == SecureHeaders::XContentTypeOptions::Constants::DEFAULT_VALUE
       end
     end
   end

--- a/fixtures/rails_3_2_12_no_init/spec/controllers/things_controller_spec.rb
+++ b/fixtures/rails_3_2_12_no_init/spec/controllers/things_controller_spec.rb
@@ -33,11 +33,16 @@ describe ThingsController do
       response.headers['Strict-Transport-Security'].should == SecureHeaders::StrictTransportSecurity::Constants::DEFAULT_VALUE
     end
 
+    it "sets the X-Content-Type-Options header" do
+      get :index
+      response.headers['X-Content-Type-Options'].should == SecureHeaders::XContentTypeOptions::Constants::DEFAULT_VALUE
+    end
+
     context "using IE" do
       it "sets the X-Content-Type-Options header" do
         request.env['HTTP_USER_AGENT'] = "Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0"
         get :index
-        response.headers['X-Content-Type-Options'].should == "nosniff"
+        response.headers['X-Content-Type-Options'].should == SecureHeaders::XContentTypeOptions::Constants::DEFAULT_VALUE
       end
     end
   end

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -85,7 +85,7 @@ module SecureHeaders
     end
 
     def set_x_content_type_options_header(options=self.class.secure_headers_options[:x_content_type_options])
-      return unless brwsr.ie?
+      return unless brwsr.ie? || brwsr.chrome?
       set_a_header(:x_content_type_options, XContentTypeOptions, options)
     end
 

--- a/lib/secure_headers/headers/x_xss_protection.rb
+++ b/lib/secure_headers/headers/x_xss_protection.rb
@@ -1,6 +1,5 @@
 module SecureHeaders
   class XXssProtectionBuildError < StandardError; end
-  # IE only
   class XXssProtection
     module Constants
       X_XSS_PROTECTION_HEADER_NAME = 'X-XSS-Protection'

--- a/spec/lib/secure_headers/headers/strict_transport_security_spec.rb
+++ b/spec/lib/secure_headers/headers/strict_transport_security_spec.rb
@@ -5,32 +5,11 @@ module SecureHeaders
     specify{ StrictTransportSecurity.new.name.should == "Strict-Transport-Security" }
 
     describe "#value" do
-      it "sets Strict Transport Security headers" do
-        s = StrictTransportSecurity.new
-        s.value.should == StrictTransportSecurity::Constants::DEFAULT_VALUE
-      end
-
-      it "allows you to specify includeSubdomains" do
-        s = StrictTransportSecurity.new(:max_age => HSTS_MAX_AGE, :include_subdomains => true)
-        s.value.should == "max-age=#{HSTS_MAX_AGE}; includeSubdomains"
-      end
-
-      it "accepts a string value and returns verbatim" do
-        s = StrictTransportSecurity.new('max-age=1234')
-        s.value.should == "max-age=1234"
-      end
-
-      it "allows you to specify max-age" do
-        age = '8675309'
-        s = StrictTransportSecurity.new(:max_age => age)
-        s.value.should == "max-age=#{age}"
-      end
-
-      it "allows you to specify max-age as a Fixnum" do
-        age = 8675309
-        s = StrictTransportSecurity.new(:max_age => age)
-        s.value.should == "max-age=#{age}"
-      end
+      specify { StrictTransportSecurity.new.value.should == StrictTransportSecurity::Constants::DEFAULT_VALUE}
+      specify { StrictTransportSecurity.new("max-age=1234").value.should == "max-age=1234"}
+      specify { StrictTransportSecurity.new(:max_age => '1234').value.should == "max-age=1234"}
+      specify { StrictTransportSecurity.new(:max_age => 1234).value.should == "max-age=1234"}
+      specify { StrictTransportSecurity.new(:max_age => HSTS_MAX_AGE, :include_subdomains => true).value.should == "max-age=#{HSTS_MAX_AGE}; includeSubdomains"}
 
       context "with an invalid configuration" do
         context "with a hash argument" do


### PR DESCRIPTION
- Chrome supports the X-Content-Type-Options header for a few use cases
  (including not processing JavaScript for text/plain content types), so
  send the X-Content-Type-Options header to Chrome users (fixes #53).
- Clean up HSTS tests to better match other header tests.
- Test X-XSS-Protection header on all browsers.
- Test X-Content-Type-Options header on both IE and Chrome.
