### PR TITLE
fixes the forwarder for Chrome

### DIFF
--- a/spec/controllers/content_security_policy_controller_spec.rb
+++ b/spec/controllers/content_security_policy_controller_spec.rb
@@ -12,7 +12,6 @@ describe ContentSecurityPolicyController do
   }
 
   class FakeRequest
-<<<<<<< HEAD
     def user_agent
       "Foo"
     end
@@ -22,8 +21,6 @@ describe ContentSecurityPolicyController do
     def remote_ip
       "123.12.45.67"
     end
-=======
->>>>>>> fixes the spec by adding a fake request with content_type
     def content_type
       "application/json"
     end


### PR DESCRIPTION
This fixes the forwarder in case anyone is using it to forward Chrome requests. The forwarder is supposed to be a temporary fix for firefox, however some people may want to use it for various other reasons such as to avoid exposing the address of their real endpoint, or forward to an internally-accessible endpoint.
