### PR TITLE
Link to repository root in README, not files in the tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ end
 * Node.js (express) [helmet](https://github.com/evilpacket/helmet) and [hood](https://github.com/seanmonstar/hood)
 * J2EE Servlet >= 3.0 [highlines](https://github.com/sourceclear/headlines)
 * ASP.NET - [NWebsec](http://nwebsec.codeplex.com/)
-* Python - [django-csp](https://github.com/mozilla/django-csp/tree/master/csp) + [commonware](https://github.com/jsocol/commonware/tree/master/commonware/request)
+* Python - [django-csp](https://github.com/mozilla/django-csp/) + [commonware](https://github.com/jsocol/commonware/)
 * Go - [secureheader](https://github.com/kr/secureheader)
 
 ## Authors


### PR DESCRIPTION
These links were pointed, somewhat confusingly, at files in the repository
instead of the repositories themselves.
