### PR TITLE
Convert specs to RSpec 2.14.8 syntax with transpec

### DIFF
--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -30,38 +30,38 @@ module SecureHeaders
 
     describe "#name" do
       context "when supplying options to override request" do
-        specify { ContentSecurityPolicy.new(default_opts, :ua => IE).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(default_opts, :ua => FIREFOX).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(default_opts, :ua => FIREFOX_23).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(default_opts, :ua => CHROME).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(default_opts, :ua => CHROME_25).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
+        specify { expect(ContentSecurityPolicy.new(default_opts, :ua => IE).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(default_opts, :ua => FIREFOX).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(default_opts, :ua => FIREFOX_23).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(default_opts, :ua => CHROME).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(default_opts, :ua => CHROME_25).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
       end
 
       context "when in report-only mode" do
-        specify { ContentSecurityPolicy.new(default_opts, :request => request_for(IE)).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(default_opts, :request => request_for(FIREFOX)).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(default_opts, :request => request_for(FIREFOX_23)).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(default_opts, :request => request_for(CHROME)).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(default_opts, :request => request_for(CHROME_25)).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
+        specify { expect(ContentSecurityPolicy.new(default_opts, :request => request_for(IE)).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(default_opts, :request => request_for(FIREFOX)).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(default_opts, :request => request_for(FIREFOX_23)).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(default_opts, :request => request_for(CHROME)).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(default_opts, :request => request_for(CHROME_25)).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
       end
 
       context "when in enforce mode" do
         let(:opts) { default_opts.merge(:enforce => true)}
 
-        specify { ContentSecurityPolicy.new(opts, :request => request_for(IE)).name.should == STANDARD_HEADER_NAME}
-        specify { ContentSecurityPolicy.new(opts, :request => request_for(FIREFOX)).name.should == STANDARD_HEADER_NAME}
-        specify { ContentSecurityPolicy.new(opts, :request => request_for(FIREFOX_23)).name.should == STANDARD_HEADER_NAME}
-        specify { ContentSecurityPolicy.new(opts, :request => request_for(CHROME)).name.should == STANDARD_HEADER_NAME}
-        specify { ContentSecurityPolicy.new(opts, :request => request_for(CHROME_25)).name.should == STANDARD_HEADER_NAME}
+        specify { expect(ContentSecurityPolicy.new(opts, :request => request_for(IE)).name).to eq(STANDARD_HEADER_NAME)}
+        specify { expect(ContentSecurityPolicy.new(opts, :request => request_for(FIREFOX)).name).to eq(STANDARD_HEADER_NAME)}
+        specify { expect(ContentSecurityPolicy.new(opts, :request => request_for(FIREFOX_23)).name).to eq(STANDARD_HEADER_NAME)}
+        specify { expect(ContentSecurityPolicy.new(opts, :request => request_for(CHROME)).name).to eq(STANDARD_HEADER_NAME)}
+        specify { expect(ContentSecurityPolicy.new(opts, :request => request_for(CHROME_25)).name).to eq(STANDARD_HEADER_NAME)}
       end
 
       context "when in experimental mode" do
         let(:opts) { default_opts.merge(:enforce => true).merge(:experimental => {})}
-        specify { ContentSecurityPolicy.new(opts, {:experimental => true, :request => request_for(IE)}).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(opts, {:experimental => true, :request => request_for(FIREFOX)}).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(opts, {:experimental => true, :request => request_for(FIREFOX_23)}).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(opts, {:experimental => true, :request => request_for(CHROME)}).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
-        specify { ContentSecurityPolicy.new(opts, {:experimental => true, :request => request_for(CHROME_25)}).name.should == STANDARD_HEADER_NAME + "-Report-Only"}
+        specify { expect(ContentSecurityPolicy.new(opts, {:experimental => true, :request => request_for(IE)}).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(opts, {:experimental => true, :request => request_for(FIREFOX)}).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(opts, {:experimental => true, :request => request_for(FIREFOX_23)}).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(opts, {:experimental => true, :request => request_for(CHROME)}).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
+        specify { expect(ContentSecurityPolicy.new(opts, {:experimental => true, :request => request_for(CHROME_25)}).name).to eq(STANDARD_HEADER_NAME + "-Report-Only")}
       end
     end
 
@@ -76,7 +76,7 @@ module SecureHeaders
       context "Content-Security-Policy" do
         it "converts the script values to their equivilents" do
           csp = ContentSecurityPolicy.new(@opts, :request => request_for(CHROME))
-          csp.value.should include("script-src 'unsafe-inline' 'unsafe-eval' https://* data: 'self' 'none'")
+          expect(csp.value).to include("script-src 'unsafe-inline' 'unsafe-eval' https://* data: 'self' 'none'")
         end
       end
     end
@@ -86,47 +86,47 @@ module SecureHeaders
 
       it "matches when host, scheme, and port match" do
         csp = ContentSecurityPolicy.new({:report_uri => 'https://example.com'}, :request => request_for(FIREFOX, "https://example.com"))
-        csp.send(:same_origin?).should be_true
+        expect(csp.send(:same_origin?)).to be_true
 
         csp = ContentSecurityPolicy.new({:report_uri => 'https://example.com'}, :request => request_for(FIREFOX, "https://example.com:443"))
-        csp.send(:same_origin?).should be_true
+        expect(csp.send(:same_origin?)).to be_true
 
         csp = ContentSecurityPolicy.new({:report_uri => 'https://example.com:123'}, :request => request_for(FIREFOX, "https://example.com:123"))
-        csp.send(:same_origin?).should be_true
+        expect(csp.send(:same_origin?)).to be_true
 
         csp = ContentSecurityPolicy.new({:report_uri => 'http://example.com'}, :request => request_for(FIREFOX, "http://example.com"))
-        csp.send(:same_origin?).should be_true
+        expect(csp.send(:same_origin?)).to be_true
 
         csp = ContentSecurityPolicy.new({:report_uri => 'http://example.com:80'}, :request => request_for(FIREFOX, "http://example.com"))
-        csp.send(:same_origin?).should be_true
+        expect(csp.send(:same_origin?)).to be_true
 
         csp = ContentSecurityPolicy.new({:report_uri => 'http://example.com'}, :request => request_for(FIREFOX, "http://example.com:80"))
-        csp.send(:same_origin?).should be_true
+        expect(csp.send(:same_origin?)).to be_true
       end
 
       it "does not match port mismatches" do
         csp = ContentSecurityPolicy.new({:report_uri => 'http://example.com'}, :request => request_for(FIREFOX, "http://example.com:81"))
-        csp.send(:same_origin?).should be_false
+        expect(csp.send(:same_origin?)).to be_false
       end
 
       it "does not match host mismatches" do
         csp = ContentSecurityPolicy.new({:report_uri => 'http://twitter.com'}, :request => request_for(FIREFOX, "http://example.com"))
-        csp.send(:same_origin?).should be_false
+        expect(csp.send(:same_origin?)).to be_false
       end
 
       it "does not match host mismatches because of subdomains" do
         csp = ContentSecurityPolicy.new({:report_uri => 'http://example.com'}, :request => request_for(FIREFOX, "http://sub.example.com"))
-        csp.send(:same_origin?).should be_false
+        expect(csp.send(:same_origin?)).to be_false
       end
 
       it "does not match scheme mismatches" do
         csp = ContentSecurityPolicy.new({:report_uri => 'https://example.com'}, :request => request_for(FIREFOX, "ftp://example.com"))
-        csp.send(:same_origin?).should be_false
+        expect(csp.send(:same_origin?)).to be_false
       end
 
       it "does not match on substring collisions" do
         csp = ContentSecurityPolicy.new({:report_uri => 'https://example.com'}, :request => request_for(FIREFOX, "https://anotherexample.com"))
-        csp.send(:same_origin?).should be_false
+        expect(csp.send(:same_origin?)).to be_false
       end
     end
 
@@ -136,29 +136,29 @@ module SecureHeaders
       context "when using firefox" do
         it "updates the report-uri when posting to a different host" do
           csp = ContentSecurityPolicy.new(opts, :request => request_for(FIREFOX, "https://anexample.com"))
-          csp.report_uri.should == FF_CSP_ENDPOINT
+          expect(csp.report_uri).to eq(FF_CSP_ENDPOINT)
         end
 
         it "doesn't change report-uri if a path supplied" do
           csp = ContentSecurityPolicy.new({:report_uri => "/csp_reports"}, :request => request_for(FIREFOX, "https://anexample.com"))
-          csp.report_uri.should == "/csp_reports"
+          expect(csp.report_uri).to eq("/csp_reports")
         end
 
         it "forwards if the request_uri is set to a non-matching value" do
           csp = ContentSecurityPolicy.new({:report_uri => "https://another.example.com", :forward_endpoint => '/somewhere'}, :ua => "Firefox", :request_uri => "https://anexample.com")
-          csp.report_uri.should == FF_CSP_ENDPOINT
+          expect(csp.report_uri).to eq(FF_CSP_ENDPOINT)
         end
       end
 
       it "does not update the URI is the report_uri is on the same origin" do
         opts = {:report_uri => 'https://example.com/csp', :forward_endpoint => 'https://anotherexample.com'}
         csp = ContentSecurityPolicy.new(opts, :request => request_for(FIREFOX, "https://example.com/somewhere"))
-        csp.report_uri.should == 'https://example.com/csp'
+        expect(csp.report_uri).to eq('https://example.com/csp')
       end
 
       it "does not update the report-uri when using a non-firefox browser" do
         csp = ContentSecurityPolicy.new(opts, :request => request_for(CHROME))
-        csp.report_uri.should == 'https://example.com/csp'
+        expect(csp.report_uri).to eq('https://example.com/csp')
       end
 
       context "when using a protocol-relative value for report-uri" do
@@ -171,20 +171,20 @@ module SecureHeaders
 
         it "uses the current protocol" do
           csp = ContentSecurityPolicy.new(opts, :request => request_for(FIREFOX, '/', :ssl => true))
-          csp.value.should =~ %r{report-uri https://example.com/csp;}
+          expect(csp.value).to match(%r{report-uri https://example.com/csp;})
 
           csp = ContentSecurityPolicy.new(opts, :request => request_for(FIREFOX))
-          csp.value.should =~ %r{report-uri http://example.com/csp;}
+          expect(csp.value).to match(%r{report-uri http://example.com/csp;})
         end
 
         it "uses the pre-configured https protocol" do
           csp = ContentSecurityPolicy.new(opts, :ua => "Firefox", :ssl => true)
-          csp.value.should =~ %r{report-uri https://example.com/csp;}
+          expect(csp.value).to match(%r{report-uri https://example.com/csp;})
         end
 
         it "uses the pre-configured http protocol" do
           csp = ContentSecurityPolicy.new(opts, :ua => "Firefox", :ssl => false)
-          csp.value.should =~ %r{report-uri http://example.com/csp;}
+          expect(csp.value).to match(%r{report-uri http://example.com/csp;})
         end
       end
     end
@@ -192,20 +192,20 @@ module SecureHeaders
     describe "#value" do
       it "raises an exception when default-src is missing" do
         csp = ContentSecurityPolicy.new({:script_src => 'anything'}, :request => request_for(CHROME))
-        lambda {
+        expect {
           csp.value
-        }.should raise_error(ContentSecurityPolicyBuildError, "Couldn't build CSP header :( Expected to find default_src directive value")
+        }.to raise_error(ContentSecurityPolicyBuildError, "Couldn't build CSP header :( Expected to find default_src directive value")
       end
 
       context "auto-whitelists data: uris for img-src" do
         it "sets the value if no img-src specified" do
           csp = ContentSecurityPolicy.new({:default_src => 'self', :disable_fill_missing => true, :disable_chrome_extension => true}, :request => request_for(CHROME))
-          csp.value.should == "default-src 'self'; img-src data:;"
+          expect(csp.value).to eq("default-src 'self'; img-src data:;")
         end
 
         it "appends the value if img-src is specified" do
           csp = ContentSecurityPolicy.new({:default_src => 'self', :img_src => 'self', :disable_fill_missing => true, :disable_chrome_extension => true}, :request => request_for(CHROME))
-          csp.value.should == "default-src 'self'; img-src 'self' data:;"
+          expect(csp.value).to eq("default-src 'self'; img-src 'self' data:;")
         end
       end
 
@@ -213,30 +213,30 @@ module SecureHeaders
         options = default_opts.merge(:disable_fill_missing => false)
         csp = ContentSecurityPolicy.new(options, :request => request_for(CHROME))
         value = "default-src https://*; connect-src https://*; font-src https://*; frame-src https://*; img-src https://* data:; media-src https://*; object-src https://*; script-src 'unsafe-inline' 'unsafe-eval' https://* data:; style-src 'unsafe-inline' https://* about:; report-uri /csp_report;"
-        csp.value.should == value
+        expect(csp.value).to eq(value)
       end
 
       it "sends the standard csp header if an unknown browser is supplied" do
         csp = ContentSecurityPolicy.new(default_opts, :request => request_for(IE))
-        csp.value.should match "default-src"
+        expect(csp.value).to match "default-src"
       end
 
       context "Firefox" do
         it "builds a csp header for firefox" do
           csp = ContentSecurityPolicy.new(default_opts, :request => request_for(FIREFOX))
-          csp.value.should == "default-src https://*; img-src data:; script-src 'unsafe-inline' 'unsafe-eval' https://* data:; style-src 'unsafe-inline' https://* about:; report-uri /csp_report;"
+          expect(csp.value).to eq("default-src https://*; img-src data:; script-src 'unsafe-inline' 'unsafe-eval' https://* data:; style-src 'unsafe-inline' https://* about:; report-uri /csp_report;")
         end
       end
 
       context "Chrome" do
         it "builds a csp header for chrome" do
           csp = ContentSecurityPolicy.new(default_opts, :request => request_for(CHROME))
-          csp.value.should == "default-src https://*; img-src data:; script-src 'unsafe-inline' 'unsafe-eval' https://* data:; style-src 'unsafe-inline' https://* about:; report-uri /csp_report;"
+          expect(csp.value).to eq("default-src https://*; img-src data:; script-src 'unsafe-inline' 'unsafe-eval' https://* data:; style-src 'unsafe-inline' https://* about:; report-uri /csp_report;")
         end
 
         it "ignores :forward_endpoint settings" do
           csp = ContentSecurityPolicy.new(@options_with_forwarding, :request => request_for(CHROME))
-          csp.value.should =~ /report-uri #{@options_with_forwarding[:report_uri]};/
+          expect(csp.value).to match(/report-uri #{@options_with_forwarding[:report_uri]};/)
         end
       end
 
@@ -253,12 +253,12 @@ module SecureHeaders
 
         it "returns the original value" do
           header = ContentSecurityPolicy.new(options, :request => request_for(CHROME))
-          header.value.should == "default-src 'self'; img-src data:; script-src https://*;"
+          expect(header.value).to eq("default-src 'self'; img-src data:; script-src https://*;")
         end
 
         it "it returns the experimental value if requested" do
           header = ContentSecurityPolicy.new(options, {:request => request_for(CHROME), :experimental => true})
-          header.value.should_not =~ /https/
+          expect(header.value).not_to match(/https/)
         end
       end
 
@@ -274,17 +274,17 @@ module SecureHeaders
 
         it "adds directive values for headers on http" do
           csp = ContentSecurityPolicy.new(options, :request => request_for(CHROME))
-          csp.value.should == "default-src https://*; frame-src http://*; img-src http://* data:; script-src 'unsafe-inline' 'unsafe-eval' https://* data:; style-src 'unsafe-inline' https://* about:; report-uri /csp_report;"
+          expect(csp.value).to eq("default-src https://*; frame-src http://*; img-src http://* data:; script-src 'unsafe-inline' 'unsafe-eval' https://* data:; style-src 'unsafe-inline' https://* about:; report-uri /csp_report;")
         end
 
         it "does not add the directive values if requesting https" do
           csp = ContentSecurityPolicy.new(options, :request => request_for(CHROME, '/', :ssl => true))
-          csp.value.should_not =~ /http:/
+          expect(csp.value).not_to match(/http:/)
         end
 
         it "does not add the directive values if requesting https" do
           csp = ContentSecurityPolicy.new(options, :ua => "Chrome", :ssl => true)
-          csp.value.should_not =~ /http:/
+          expect(csp.value).not_to match(/http:/)
         end
 
         context "when supplying an experimental block" do
@@ -314,17 +314,17 @@ module SecureHeaders
 
           it "uses the value in the experimental block over SSL" do
             csp = ContentSecurityPolicy.new(options, :experimental => true, :request => request_for(FIREFOX, '/', :ssl => true))
-            csp.value.should == "default-src 'self'; img-src data:; script-src 'self';"
+            expect(csp.value).to eq("default-src 'self'; img-src data:; script-src 'self';")
           end
 
           it "detects the :ssl => true option" do
             csp = ContentSecurityPolicy.new(options, :experimental => true, :ua => FIREFOX, :ssl => true)
-            csp.value.should == "default-src 'self'; img-src data:; script-src 'self';"
+            expect(csp.value).to eq("default-src 'self'; img-src data:; script-src 'self';")
           end
 
           it "merges the values from experimental/http_additions when not over SSL" do
             csp = ContentSecurityPolicy.new(options, :experimental => true, :request => request_for(FIREFOX))
-            csp.value.should == "default-src 'self'; img-src data:; script-src 'self' https://mycdn.example.com;"
+            expect(csp.value).to eq("default-src 'self'; img-src data:; script-src 'self' https://mycdn.example.com;")
           end
         end
       end
@@ -338,21 +338,21 @@ module SecureHeaders
 
         it "uses the value in the X-Webkit-CSP" do
           csp = ContentSecurityPolicy.new(options, :request => request_for(CHROME))
-          csp.value.should match "script-nonce random;"
+          expect(csp.value).to match "script-nonce random;"
         end
 
         it "runs a dynamic nonce generator" do
           options[:script_nonce] = lambda { 'something' }
           csp = ContentSecurityPolicy.new(options, :request => request_for(CHROME))
-          csp.value.should match "script-nonce something;"
+          expect(csp.value).to match "script-nonce something;"
         end
 
         it "runs against the given controller context" do
           fake_params = {}
           options[:script_nonce] = lambda { params[:script_nonce] = 'something' }
           csp = ContentSecurityPolicy.new(options, :request => request_for(CHROME), :controller => double(:params => fake_params))
-          csp.value.should match "script-nonce something;"
-          fake_params.should == {:script_nonce => 'something'}
+          expect(csp.value).to match "script-nonce something;"
+          expect(fake_params).to eq({:script_nonce => 'something'})
         end
       end
     end

--- a/spec/lib/secure_headers/headers/strict_transport_security_spec.rb
+++ b/spec/lib/secure_headers/headers/strict_transport_security_spec.rb
@@ -2,59 +2,59 @@ require 'spec_helper'
 
 module SecureHeaders
   describe StrictTransportSecurity do
-    specify{ StrictTransportSecurity.new.name.should == "Strict-Transport-Security" }
+    specify{ expect(StrictTransportSecurity.new.name).to eq("Strict-Transport-Security") }
 
     describe "#value" do
-      specify { StrictTransportSecurity.new.value.should == StrictTransportSecurity::Constants::DEFAULT_VALUE}
-      specify { StrictTransportSecurity.new("max-age=1234").value.should == "max-age=1234"}
-      specify { StrictTransportSecurity.new(:max_age => '1234').value.should == "max-age=1234"}
-      specify { StrictTransportSecurity.new(:max_age => 1234).value.should == "max-age=1234"}
-      specify { StrictTransportSecurity.new(:max_age => HSTS_MAX_AGE, :include_subdomains => true).value.should == "max-age=#{HSTS_MAX_AGE}; includeSubdomains"}
+      specify { expect(StrictTransportSecurity.new.value).to eq(StrictTransportSecurity::Constants::DEFAULT_VALUE)}
+      specify { expect(StrictTransportSecurity.new("max-age=1234").value).to eq("max-age=1234")}
+      specify { expect(StrictTransportSecurity.new(:max_age => '1234').value).to eq("max-age=1234")}
+      specify { expect(StrictTransportSecurity.new(:max_age => 1234).value).to eq("max-age=1234")}
+      specify { expect(StrictTransportSecurity.new(:max_age => HSTS_MAX_AGE, :include_subdomains => true).value).to eq("max-age=#{HSTS_MAX_AGE}; includeSubdomains")}
 
       context "with an invalid configuration" do
         context "with a hash argument" do
           it "should allow string values for max-age" do
-            lambda {
+            expect {
               StrictTransportSecurity.new(:max_age => '1234')
-            }.should_not raise_error
+            }.not_to raise_error
           end
 
           it "should allow integer values for max-age" do
-            lambda {
+            expect {
               StrictTransportSecurity.new(:max_age => 1234)
-            }.should_not raise_error
+            }.not_to raise_error
           end
 
           it "raises an exception with an invalid max-age" do
-            lambda {
+            expect {
               StrictTransportSecurity.new(:max_age => 'abc123')
-            }.should raise_error(STSBuildError)
+            }.to raise_error(STSBuildError)
           end
 
           it "raises an exception if max-age is not supplied" do
-            lambda {
+            expect {
               StrictTransportSecurity.new(:includeSubdomains => true)
-            }.should raise_error(STSBuildError)
+            }.to raise_error(STSBuildError)
           end
         end
 
         context "with a string argument" do
           it "raises an exception with an invalid max-age" do
-            lambda {
+            expect {
               StrictTransportSecurity.new('max-age=abc123')
-            }.should raise_error(STSBuildError)
+            }.to raise_error(STSBuildError)
           end
 
           it "raises an exception if max-age is not supplied" do
-            lambda {
+            expect {
               StrictTransportSecurity.new('includeSubdomains')
-            }.should raise_error(STSBuildError)
+            }.to raise_error(STSBuildError)
           end
 
           it "raises an exception with an invalid format" do
-            lambda {
+            expect {
               StrictTransportSecurity.new('max-age=123includeSubdomains')
-            }.should raise_error(STSBuildError)
+            }.to raise_error(STSBuildError)
           end
         end
       end

--- a/spec/lib/secure_headers/headers/x_content_type_options_spec.rb
+++ b/spec/lib/secure_headers/headers/x_content_type_options_spec.rb
@@ -1,33 +1,33 @@
 module SecureHeaders
   describe XContentTypeOptions do
-    specify{ XContentTypeOptions.new.name.should == "X-Content-Type-Options" }
+    specify{ expect(XContentTypeOptions.new.name).to eq("X-Content-Type-Options") }
 
     describe "#value" do
-      specify { XContentTypeOptions.new.value.should == XContentTypeOptions::Constants::DEFAULT_VALUE}
-      specify { XContentTypeOptions.new("nosniff").value.should == "nosniff"}
-      specify { XContentTypeOptions.new(:value => 'nosniff').value.should == "nosniff"}
+      specify { expect(XContentTypeOptions.new.value).to eq(XContentTypeOptions::Constants::DEFAULT_VALUE)}
+      specify { expect(XContentTypeOptions.new("nosniff").value).to eq("nosniff")}
+      specify { expect(XContentTypeOptions.new(:value => 'nosniff').value).to eq("nosniff")}
 
       context "invalid configuration values" do
         it "accepts nosniff" do
-          lambda {
+          expect {
             XContentTypeOptions.new("nosniff")
-          }.should_not raise_error
+          }.not_to raise_error
 
-          lambda {
+          expect {
             XContentTypeOptions.new(:value => "nosniff")
-          }.should_not raise_error
+          }.not_to raise_error
         end
 
         it "accepts nil" do
-          lambda {
+          expect {
             XContentTypeOptions.new
-          }.should_not raise_error
+          }.not_to raise_error
         end
 
         it "doesn't accept anything besides no-sniff" do
-          lambda {
+          expect {
             XContentTypeOptions.new("donkey")
-          }.should raise_error
+          }.to raise_error
         end
       end
     end

--- a/spec/lib/secure_headers/headers/x_frame_options_spec.rb
+++ b/spec/lib/secure_headers/headers/x_frame_options_spec.rb
@@ -2,34 +2,34 @@ require 'spec_helper'
 
 module SecureHeaders
   describe XFrameOptions do
-    specify{ XFrameOptions.new.name.should == "X-Frame-Options" }
+    specify{ expect(XFrameOptions.new.name).to eq("X-Frame-Options") }
 
     describe "#value" do
-      specify { XFrameOptions.new.value.should == XFrameOptions::Constants::DEFAULT_VALUE}
-      specify { XFrameOptions.new("SAMEORIGIN").value.should == "SAMEORIGIN"}
-      specify { XFrameOptions.new(:value => 'DENY').value.should == "DENY"}
+      specify { expect(XFrameOptions.new.value).to eq(XFrameOptions::Constants::DEFAULT_VALUE)}
+      specify { expect(XFrameOptions.new("SAMEORIGIN").value).to eq("SAMEORIGIN")}
+      specify { expect(XFrameOptions.new(:value => 'DENY').value).to eq("DENY")}
 
       context "with invalid configuration" do
         it "allows SAMEORIGIN" do
-          lambda {
+          expect {
             XFrameOptions.new("SAMEORIGIN").value
-          }.should_not raise_error
+          }.not_to raise_error
         end
 
         it "allows DENY" do
-          lambda {
+          expect {
             XFrameOptions.new("DENY").value
-          }.should_not raise_error        end
+          }.not_to raise_error        end
 
         it "allows ALLOW-FROM*" do
-          lambda {
+          expect {
             XFrameOptions.new("ALLOW-FROM: example.com").value
-          }.should_not raise_error
+          }.not_to raise_error
         end
         it "does not allow garbage" do
-          lambda {
+          expect {
             XFrameOptions.new("I like turtles").value
-          }.should raise_error(XFOBuildError)
+          }.to raise_error(XFOBuildError)
         end
       end
     end

--- a/spec/lib/secure_headers/headers/x_xss_protection_spec.rb
+++ b/spec/lib/secure_headers/headers/x_xss_protection_spec.rb
@@ -1,50 +1,50 @@
 module SecureHeaders
   describe XXssProtection do
-    specify { XXssProtection.new.name.should == X_XSS_PROTECTION_HEADER_NAME}
-    specify { XXssProtection.new.value.should == "1"}
-    specify { XXssProtection.new("0").value.should == "0"}
-    specify { XXssProtection.new(:value => 1, :mode => 'block').value.should == '1; mode=block' }
+    specify { expect(XXssProtection.new.name).to eq(X_XSS_PROTECTION_HEADER_NAME)}
+    specify { expect(XXssProtection.new.value).to eq("1")}
+    specify { expect(XXssProtection.new("0").value).to eq("0")}
+    specify { expect(XXssProtection.new(:value => 1, :mode => 'block').value).to eq('1; mode=block') }
 
     context "with invalid configuration" do
       it "should raise an error when providing a string that is not valid" do
-        lambda {
+        expect {
           XXssProtection.new("asdf")
-        }.should raise_error(XXssProtectionBuildError)
+        }.to raise_error(XXssProtectionBuildError)
 
-        lambda {
+        expect {
           XXssProtection.new("asdf; mode=donkey")
-        }.should raise_error(XXssProtectionBuildError)
+        }.to raise_error(XXssProtectionBuildError)
       end
 
       context "when using a hash value" do
         it "should allow string values ('1' or '0' are the only valid strings)" do
-          lambda {
+          expect {
             XXssProtection.new(:value => '1')
-          }.should_not raise_error
+          }.not_to raise_error
         end
 
         it "should allow integer values (1 or 0 are the only valid integers)" do
-          lambda {
+          expect {
             XXssProtection.new(:value => 1)
-          }.should_not raise_error
+          }.not_to raise_error
         end
 
         it "should raise an error if no value key is supplied" do
-          lambda {
+          expect {
             XXssProtection.new(:mode => 'block')
-          }.should raise_error(XXssProtectionBuildError)
+          }.to raise_error(XXssProtectionBuildError)
         end
 
         it "should raise an error if an invalid key is supplied" do
-          lambda {
+          expect {
             XXssProtection.new(:value => 123)
-          }.should raise_error(XXssProtectionBuildError)
+          }.to raise_error(XXssProtectionBuildError)
         end
 
         it "should raise an error if mode != block" do
-          lambda {
+          expect {
             XXssProtection.new(:value => 1, :mode => "donkey")
-          }.should raise_error(XXssProtectionBuildError)
+          }.to raise_error(XXssProtectionBuildError)
         end
       end
 

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -13,9 +13,9 @@ describe SecureHeaders do
 
   before(:each) do
     stub_user_agent(nil)
-    headers.stub(:[])
-    subject.stub(:response).and_return(response)
-    subject.stub(:request).and_return(request)
+    allow(headers).to receive(:[])
+    allow(subject).to receive(:response).and_return(response)
+    allow(subject).to receive(:request).and_return(request)
   end
 
   ALL_HEADERS = Hash[[:hsts, :csp, :x_frame_options, :x_content_type_options, :x_xss_protection].map{|header| [header, false]}]
@@ -32,11 +32,11 @@ describe SecureHeaders do
   }
 
   def should_assign_header name, value
-    response.headers.should_receive(:[]=).with(name, value)
+    expect(response.headers).to receive(:[]=).with(name, value)
   end
 
   def should_not_assign_header name
-    response.headers.should_not_receive(:[]=).with(name, anything)
+    expect(response.headers).not_to receive(:[]=).with(name, anything)
   end
 
   def stub_user_agent val
@@ -68,7 +68,7 @@ describe SecureHeaders do
   describe "#ensure_security_headers" do
     it "sets a before filter" do
       options = {}
-      DummyClass.should_receive(:before_filter).exactly(5).times
+      expect(DummyClass).to receive(:before_filter).exactly(5).times
       DummyClass.ensure_security_headers(options)
     end
   end
@@ -87,13 +87,13 @@ describe SecureHeaders do
 
   describe "#set_security_headers" do
     before(:each) do
-      SecureHeaders::ContentSecurityPolicy.stub(:new).and_return(double.as_null_object)
+      allow(SecureHeaders::ContentSecurityPolicy).to receive(:new).and_return(double.as_null_object)
     end
     USER_AGENTS.each do |name, useragent|
       it "sets all default headers for #{name} (smoke test)" do
         stub_user_agent(useragent)
         number_of_headers = 5
-        subject.should_receive(:set_header).exactly(number_of_headers).times # a request for a given header
+        expect(subject).to receive(:set_header).exactly(number_of_headers).times # a request for a given header
         subject.set_csp_header
         subject.set_x_frame_options_header
         subject.set_hsts_header
@@ -144,7 +144,7 @@ describe SecureHeaders do
           config.x_xss_protection = false
           config.csp = false
         end
-        subject.should_not_receive(:set_header)
+        expect(subject).not_to receive(:set_header)
         set_security_headers(subject)
         reset_config
       end


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 75 conversions
  from: obj.should
    to: expect(obj).to
- 54 conversions
  from: == expected
    to: eq(expected)
- 14 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
- 13 conversions
  from: lambda { }.should
    to: expect { }.to
- 10 conversions
  from: lambda { }.should_not
    to: expect { }.not_to
- 8 conversions
  from: =~ /pattern/
    to: match(/pattern/)
- 8 conversions
  from: obj.should_receive(:message)
    to: expect(obj).to receive(:message)
- 5 conversions
  from: obj.should_not_receive(:message)
    to: expect(obj).not_to receive(:message)
- 3 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 1 conversion
  from: Klass.any_instance.stub(:message)
    to: allow_any_instance_of(Klass).to receive(:message)
