### PR TITLE
Implemented Padrino hook in a more Padrino way

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,27 +268,35 @@ In your `Gemfile`:
 then in your `app.rb` file you can:
 
 ```ruby
+require 'secure_headers/padrino'
+
 module Web
   class App < Padrino::Application
-    include SecureHeaders
-
-    ::SecureHeaders::Configuration.configure do |config|
-      config.hsts                   = {:max_age => 99, :include_subdomains => true}
-      config.x_frame_options        = 'DENY'
-      config.x_content_type_options = "nosniff"
-      config.x_xss_protection       = {:value   => '1', :mode => false}
-      config.csp                    = {
-        :default_src => "https://* inline eval",
-        :report_uri => '//example.com/uri-directive',
-        :img_src => "https://* data:",
-        :frame_src => "https://* http://*.twimg.com http://itunes.apple.com"
-      }
-    end
+    register SecureHeaders::Padrino
 
     get '/' do
       set_csp_header
       render 'index'
     end
+  end
+end
+```
+
+and in `config/boot.rb`:
+
+```ruby
+def before_load
+  ::SecureHeaders::Configuration.configure do |config|
+    config.hsts                   = {:max_age => 99, :include_subdomains => true}
+    config.x_frame_options        = 'DENY'
+    config.x_content_type_options = "nosniff"
+    config.x_xss_protection       = {:value   => '1', :mode => false}
+    config.csp                    = {
+      :default_src => "https://* inline eval",
+      :report_uri => '//example.com/uri-directive',
+      :img_src => "https://* data:",
+      :frame_src => "https://* http://*.twimg.com http://itunes.apple.com"
+    }
   end
 end
 ```

--- a/lib/secure_headers/padrino.rb
+++ b/lib/secure_headers/padrino.rb
@@ -1,0 +1,14 @@
+module SecureHeaders
+  module Padrino
+    class << self
+      ##
+      # Main class that register this extension.
+      #
+      def registered(app)
+        app.extend SecureHeaders::ClassMethods
+        app.helpers SecureHeaders::InstanceMethods
+      end
+      alias :included :registered
+    end
+  end
+end


### PR DESCRIPTION
Hi guys,

First of all, thanks a million for having a Padrino example in place :). Much appreciated!! I was reviewing our plugin requests and spotted one for `secureheaders` padrino/padrino-recipes#46 (ref padrino/padrino-framework#1048), so I came around your gem and found that we could make the integration a bit more Padrino style.
This PR implements a register hook closer to the way we load most gems. It also hints that the configuration should be moved towards `before_load` in `config/boot.rb`.

What do you think about that?
Thanks, :)
Darío

/cc @postmodern @achiu
