### PR TITLE
Rescue from URI error

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -164,6 +164,8 @@ module SecureHeaders
       origin = URI.parse(request_uri)
       uri = URI.parse(report_uri)
       uri.host == origin.host && origin.port == uri.port && origin.scheme == uri.scheme
+    rescue URI::InvalidURIError
+      true
     end
 
     def report_uri_directive


### PR DESCRIPTION
It sometimes happen that the URI fails to parse in the `same_origin?` call for some reason. Not sure why, but this will default the `same_origin?` to a sane default.

One such URL is: `https://checkout.shopify.com/2577737/policies/1172141?__utma=1.1044498411.1406634492.1406634492.1406644613.2&__utmb=1.10.10.1406644613&__utmc=1&__utmx=-&__utmz=1.1406644613.2.2.utmcsr=l.facebook.com|utmccn=(referral)|utmcmd=referral|utmcct=/l.php&__utmv=-&__utmk=256236555`

![screen shot 2014-07-29 at 11 31 43 am](https://cloud.githubusercontent.com/assets/2053039/3737278/7cff2fa4-1735-11e4-96cd-62ea5bfe7428.png)
