### PR TITLE
add the ability to tag requests with report-only and app_name information

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -60,9 +60,9 @@ module SecureHeaders
         @config.merge!(experimental_config)
       end
 
-      # http_additions will be the only field that still doesn't support
-      # lambdas because it's an ugly api that's showing it's age.
+      # these values don't support lambdas because this needs to be rewritten
       @http_additions = @config.delete(:http_additions)
+      @app_name = @config.delete(:app_name)
 
       normalize_csp_options
 
@@ -70,7 +70,9 @@ module SecureHeaders
         self.send("#{meta}=", @config.delete(meta))
       end
 
-      @enforce = @config.delete(:enforce)
+      @enforce = !!@config.delete(:enforce)
+      @tag_report_uri = @config.delete(:tag_report_uri)
+
       normalize_reporting_endpoint
       fill_directives unless disable_fill_missing?
     end
@@ -171,6 +173,11 @@ module SecureHeaders
         if forward_endpoint
           @report_uri = FF_CSP_ENDPOINT
         end
+      end
+
+      if @tag_report_uri
+        @report_uri = "#{@report_uri}?enforce=#{@enforce}"
+        @report_uri += "&app_name=#{@app_name}" if @app_name
       end
     end
 

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -79,6 +79,18 @@ module SecureHeaders
           expect(csp.value).to include("script-src 'unsafe-inline' 'unsafe-eval' https://* data: 'self' 'none'")
         end
 
+        it "adds a @enforce and @app_name variables to the report uri" do
+          opts = @opts.merge(:tag_report_uri => true, :enforce => true, :app_name => 'twitter')
+          csp = ContentSecurityPolicy.new(opts, :request => request_for(CHROME))
+          expect(csp.value).to include("/csp_report?enforce=true&app_name=twitter")
+        end
+
+        it "does not add an empty @app_name variable to the report uri" do
+          opts = @opts.merge(:tag_report_uri => true, :enforce => true)
+          csp = ContentSecurityPolicy.new(opts, :request => request_for(CHROME))
+          expect(csp.value).to include("/csp_report?enforce=true")
+        end
+
         it "accepts procs for report-uris" do
           opts = {
             :default_src => 'self',


### PR DESCRIPTION
this has been really helpful for twitter. it's opt in, maybe it can be helpful to you.
