### PR TITLE
Add support for new HSTS 'preload' option

### DIFF
--- a/lib/secure_headers/headers/strict_transport_security.rb
+++ b/lib/secure_headers/headers/strict_transport_security.rb
@@ -6,7 +6,7 @@ module SecureHeaders
       HSTS_HEADER_NAME = 'Strict-Transport-Security'
       HSTS_MAX_AGE = "631138519"
       DEFAULT_VALUE = "max-age=" + HSTS_MAX_AGE
-      VALID_STS_HEADER = /\Amax-age=\d+(; includeSubdomains)?\z/i
+      VALID_STS_HEADER = /\Amax-age=\d+(; includeSubdomains)?(; preload)?\z/i
       MESSAGE = "The config value supplied for the HSTS header was invalid."
     end
     include Constants
@@ -31,6 +31,7 @@ module SecureHeaders
       max_age = @config.fetch(:max_age, HSTS_MAX_AGE)
       value = "max-age=" + max_age.to_s
       value += "; includeSubdomains" if @config[:include_subdomains]
+      value += "; preload" if @config[:preload]
 
       value
     end

--- a/spec/lib/secure_headers/headers/strict_transport_security_spec.rb
+++ b/spec/lib/secure_headers/headers/strict_transport_security_spec.rb
@@ -10,6 +10,7 @@ module SecureHeaders
       specify { expect(StrictTransportSecurity.new(:max_age => '1234').value).to eq("max-age=1234")}
       specify { expect(StrictTransportSecurity.new(:max_age => 1234).value).to eq("max-age=1234")}
       specify { expect(StrictTransportSecurity.new(:max_age => HSTS_MAX_AGE, :include_subdomains => true).value).to eq("max-age=#{HSTS_MAX_AGE}; includeSubdomains")}
+      specify { expect(StrictTransportSecurity.new(:max_age => HSTS_MAX_AGE, :include_subdomains => true, :preload => true).value).to eq("max-age=#{HSTS_MAX_AGE}; includeSubdomains; preload")}
 
       context "with an invalid configuration" do
         context "with a hash argument" do

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -178,6 +178,11 @@ describe SecureHeaders do
       should_assign_header(HSTS_HEADER_NAME, "max-age=#{HSTS_MAX_AGE}; includeSubdomains")
       subject.set_hsts_header(:max_age => HSTS_MAX_AGE, :include_subdomains => true)
     end
+
+    it "allows you to specify preload" do
+      should_assign_header(HSTS_HEADER_NAME, "max-age=#{HSTS_MAX_AGE}; includeSubdomains; preload")
+      subject.set_hsts_header(:max_age => HSTS_MAX_AGE, :include_subdomains => true, :preload => true)
+    end
   end
 
   describe "#set_x_xss_protection" do


### PR DESCRIPTION
@agl just made a new option for HSTS representing confirmation that a site wants to be included in a browser's preload list (https://hstspreload.appspot.com).

This just adds a new 'preload' option to the HSTS settings to specify that option.
