### PR TITLE
Defer loading action_controller

### DIFF
--- a/lib/secure_headers/railtie.rb
+++ b/lib/secure_headers/railtie.rb
@@ -3,7 +3,11 @@ if defined?(Rails::Railtie)
   module SecureHeaders
     class Railtie < Rails::Engine
       isolate_namespace ::SecureHeaders if defined? isolate_namespace # rails 3.0
-      ActionController::Base.send :include, ::SecureHeaders
+      initializer "secure_headers.action_controller" do
+        ActiveSupport.on_load(:action_controller) do
+          include ::SecureHeaders
+        end
+      end
     end
   end
 else


### PR DESCRIPTION
Use the lazy-load hooks to include ::SecureHeaders. This will prevent action_controller/action_view from getting loaded unless it's required. i.e Rake task.
