### PR TITLE
Fix support for mutliple script hashes

### DIFF
--- a/lib/secure_headers/script_hash.rb
+++ b/lib/secure_headers/script_hash.rb
@@ -32,7 +32,7 @@ module SecureHeaders
 
       # need to settle on stuffs
     def hash_source_expression(hashes, format = "sha256", delimeter = "-", hash_delimeter = " ", wrapper = "'")
-      wrapper + format + delimeter + hashes.join(hash_delimeter) + wrapper
+      hashes.map { |hash| wrapper + format + delimeter + hash + wrapper }
     end
   end
 


### PR DESCRIPTION
There exists a bug which causes ian improperly formatted `script-src`
expression for multiple script hashes. As is, the output for two hash
`abcde` and `fjhij` is:

```
script-src 'sha256-abcde fghij'
```

This should be:

```
script-src 'sha256-abcde' 'sha256-fghij'
```
