### PR TITLE
Add report=uri to X-XSS-Protection

### DIFF
--- a/lib/secure_headers/headers/x_xss_protection.rb
+++ b/lib/secure_headers/headers/x_xss_protection.rb
@@ -4,7 +4,7 @@ module SecureHeaders
     module Constants
       X_XSS_PROTECTION_HEADER_NAME = 'X-XSS-Protection'
       DEFAULT_VALUE = "1"
-      VALID_X_XSS_HEADER = /\A[01](; mode=block)?\z/i
+      VALID_X_XSS_HEADER = /\A[01](; mode=block)?(; report=.*)?\z/i
     end
     include Constants
 
@@ -26,6 +26,7 @@ module SecureHeaders
       else
         value = @config[:value].to_s
         value += "; mode=#{@config[:mode]}" if @config[:mode]
+        value += "; report=#{@config[:report_uri]}" if @config[:report_uri]
         value
       end
     end

--- a/spec/lib/secure_headers/headers/x_xss_protection_spec.rb
+++ b/spec/lib/secure_headers/headers/x_xss_protection_spec.rb
@@ -4,6 +4,7 @@ module SecureHeaders
     specify { expect(XXssProtection.new.value).to eq("1")}
     specify { expect(XXssProtection.new("0").value).to eq("0")}
     specify { expect(XXssProtection.new(:value => 1, :mode => 'block').value).to eq('1; mode=block') }
+    specify { expect(XXssProtection.new(:value => 1, :mode => 'block', :report_uri => 'https://www.secure.com/reports').value).to eq('1; mode=block; report=https://www.secure.com/reports') }
 
     context "with invalid configuration" do
       it "should raise an error when providing a string that is not valid" do


### PR DESCRIPTION
Adds this new `report` argument to the `X-XSS-Protection` header.

Details: https://bugs.webkit.org/show_bug.cgi?id=100892

@oreoshake 
