### PR TITLE
do not eager-load controllers which causes all helpers to get loaded

### DIFF
--- a/lib/secure_headers/railtie.rb
+++ b/lib/secure_headers/railtie.rb
@@ -3,6 +3,7 @@ if defined?(Rails::Railtie)
   module SecureHeaders
     class Railtie < Rails::Engine
       isolate_namespace ::SecureHeaders if defined? isolate_namespace # rails 3.0
+      config.eager_load_paths = [] if ['test', 'development'].include?(Rails.env)
       initializer "secure_headers.action_controller" do
         ActiveSupport.on_load(:action_controller) do
           include ::SecureHeaders


### PR DESCRIPTION
@oreoshake

this prevents the controller and therefore all  helpers (default is :all) to get loaded, saving startup time and dependent requires from helpers

before:

```
runs: 10
total: 126.17
average: 12.62
range: 12.26..12.86
```

after:

```
runs: 10
total: 123.67
average: 12.37
range: 12.06..12.55
```
