### PR TITLE
XDownloadOptions spec referenced wrong class

### DIFF
--- a/spec/lib/secure_headers/headers/x_download_options_spec.rb
+++ b/spec/lib/secure_headers/headers/x_download_options_spec.rb
@@ -24,7 +24,7 @@ module SecureHeaders
 
       it "doesn't accept anything besides noopen" do
         expect {
-          XContentTypeOptions.new("open")
+          XDownloadOptions.new("open")
         }.to raise_error
       end
     end


### PR DESCRIPTION
I found a small typo in the XDownloadOptions spec. The test asserted failure so this was failing for the wrong reasons most likely.

I was tempted to change this to `described_class` but opted not to since none of the other specs are written that way.
