### PR TITLE
Make yet another exception for 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,6 @@ group :test do
   gem 'growl'
   gem 'rb-fsevent'
   gem 'coveralls', :platform => :ruby_19
+
+  gem 'i18n', '~< 0.6.0', :platform => :ruby_18
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,5 @@ group :test do
   gem 'growl'
   gem 'rb-fsevent'
   gem 'coveralls', :platform => :ruby_19
-
-  gem 'i18n', '~< 0.6.0', :platform => :ruby_18
+  gem 'i18n', '< 0.7.0', :platform => :ruby_18
 end


### PR DESCRIPTION
Should probably just :fire: 1.8.7 support but this works.