### PR TITLE
Include ActionView helpers in ActionView::Base

### DIFF
--- a/lib/secure_headers/view_helper.rb
+++ b/lib/secure_headers/view_helper.rb
@@ -62,7 +62,7 @@ module SecureHeaders
 end
 
 module ActionView #:nodoc:
-  module Helpers #:nodoc:
+  class Base #:nodoc:
     include SecureHeaders::ViewHelpers
   end
 end


### PR DESCRIPTION
Including `SecureHeaders::ViewHelpers` directly into `ActionView::Helpers` does *not* make them available in views in Rails 4.2. Including the helper module directly into `ActionView::Base` makes them available.

I'm not sure if this is going to fly in Rails 3.x, will have to wait for the results from Travis.