### PR TITLE
Pass reference to controller to CSP callable config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This gem makes a few assumptions about how you will use some features.  For exam
   config.x_permitted_cross_domain_policies = 'none'
   config.csp = {
     :default_src => "https: self",
+    :enforce => proc {|controller| contoller.current_user.enforce_csp? }
     :frame_src => "https: http:.twimg.com http://itunes.apple.com",
     :img_src => "https:",
     :report_uri => '//example.com/uri-directive'

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -106,7 +106,7 @@ module SecureHeaders
 
       # Config values can be string, array, or lamdba values
       @config = config.inject({}) do |hash, (key, value)|
-        config_val = value.respond_to?(:call) ? value.call : value
+        config_val = value.respond_to?(:call) ? value.call(@controller) : value
 
         if SOURCE_DIRECTIVES.include?(key) # directives need to be normalized to arrays of strings
           config_val = config_val.split if config_val.is_a? String


### PR DESCRIPTION
Without this, the code executes in the context of `SecureHeaders::Configuration:Module` which is pretty useless.

e.g.

```
   :enforce => lambda { |controller| controller.current_user.beta_testing? }
```

This is kind of a breaking change, if `lambda`s were using instead of `proc`s since the lambda enforces the passed in value.