### PR TITLE
Sniff for nonce support

### DIFF
--- a/fixtures/rails_3_2_12/spec/controllers/other_things_controller_spec.rb
+++ b/fixtures/rails_3_2_12/spec/controllers/other_things_controller_spec.rb
@@ -13,7 +13,7 @@ describe OtherThingsController, :type => :controller do
     options = opts.merge(
       {
         'HTTPS' => 'on',
-        'HTTP_USER_AGENT' => "Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0"
+        'HTTP_USER_AGENT' => "Mozilla/5.0 (Macintosh; Intel Mac OS X 1084) AppleWebKit/537.22 (KHTML like Gecko) Chrome/25.0.1364.99 Safari/537.22"
       }
     )
 

--- a/fixtures/rails_4_1_8/spec/controllers/other_things_controller_spec.rb
+++ b/fixtures/rails_4_1_8/spec/controllers/other_things_controller_spec.rb
@@ -13,7 +13,7 @@ describe OtherThingsController, :type => :controller do
     options = opts.merge(
       {
         'HTTPS' => 'on',
-        'HTTP_USER_AGENT' => "Mozilla/5.0 (compatible; MSIE 10.6; Windows NT 6.1; Trident/5.0; InfoPath.2; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 2.0.50727) 3gpp-gba UNTRUSTED/1.0"
+        'HTTP_USER_AGENT' => "Mozilla/5.0 (Macintosh; Intel Mac OS X 1084) AppleWebKit/537.22 (KHTML like Gecko) Chrome/25.0.1364.99 Safari/537.22"
       }
     )
 

--- a/secure_headers.gemspec
+++ b/secure_headers.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.add_development_dependency "rake"
+  gem.add_dependency "user_agent_parser"
   gem.post_install_message = "Warning: lambda config values will be broken until you add |controller|. e.g. :enforce => lambda { |controller| some_expression }"
 end

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -195,7 +195,7 @@ module SecureHeaders
           expect(header.value).to include("script-src 'self' 'nonce-#{header.nonce}' 'unsafe-inline'")
         end
 
-        it "adds a nonce and unsafe-inline to the script-src value when using firefox" do
+        it "adds a nonce and unsafe-inline to the script-src value when using opera" do
           header = ContentSecurityPolicy.new(default_opts.merge(:script_src => "self nonce"), :request => request_for(OPERA))
           expect(header.value).to include("script-src 'self' 'nonce-#{header.nonce}' 'unsafe-inline'")
         end

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -17,7 +17,8 @@ module SecureHeaders
     FIREFOX_23 = "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:23.0) Gecko/20131011 Firefox/23.0"
     CHROME = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_4; en-US) AppleWebKit/533.4 (KHTML, like Gecko) Chrome/5.0.375.99 Safari/533.4"
     CHROME_25 = "Mozilla/5.0 (Macintosh; Intel Mac OS X 1084) AppleWebKit/537.22 (KHTML like Gecko) Chrome/25.0.1364.99 Safari/537.22"
-
+    SAFARI = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A"
+    OPERA = "Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16"
 
     def request_for user_agent, request_uri=nil, options={:ssl => false}
       double(:ssl? => options[:ssl], :env => {'HTTP_USER_AGENT' => user_agent}, :url => (request_uri || 'http://areallylongdomainexample.com') )
@@ -184,9 +185,31 @@ module SecureHeaders
       end
 
       context "when using a nonce" do
-        it "adds a nonce and unsafe-inline to the script-src value" do
+        it "adds a nonce and unsafe-inline to the script-src value when using chrome" do
           header = ContentSecurityPolicy.new(default_opts.merge(:script_src => "self nonce"), :request => request_for(CHROME))
           expect(header.value).to include("script-src 'self' 'nonce-#{header.nonce}' 'unsafe-inline'")
+        end
+
+        it "adds a nonce and unsafe-inline to the script-src value when using firefox" do
+          header = ContentSecurityPolicy.new(default_opts.merge(:script_src => "self nonce"), :request => request_for(FIREFOX))
+          expect(header.value).to include("script-src 'self' 'nonce-#{header.nonce}' 'unsafe-inline'")
+        end
+
+        it "adds a nonce and unsafe-inline to the script-src value when using firefox" do
+          header = ContentSecurityPolicy.new(default_opts.merge(:script_src => "self nonce"), :request => request_for(OPERA))
+          expect(header.value).to include("script-src 'self' 'nonce-#{header.nonce}' 'unsafe-inline'")
+        end
+
+        it "does not add a nonce and unsafe-inline to the script-src value when using Safari" do
+          header = ContentSecurityPolicy.new(default_opts.merge(:script_src => "self nonce"), :request => request_for(SAFARI))
+          expect(header.value).to include("script-src 'self' 'unsafe-inline'")
+          expect(header.value).not_to include("nonce")
+        end
+
+        it "does not add a nonce and unsafe-inline to the script-src value when using IE" do
+          header = ContentSecurityPolicy.new(default_opts.merge(:script_src => "self nonce"), :request => request_for(IE))
+          expect(header.value).to include("script-src 'self' 'unsafe-inline'")
+          expect(header.value).not_to include("nonce")
         end
 
         it "adds a nonce and unsafe-inline to the style-src value" do


### PR DESCRIPTION
Because safari pukes when it sees a nonce. it still works (falls back to `unsafe-inline`) but it's unsightly. 

<img width="467" alt="screen shot 2015-06-24 at 11 56 04 am" src="https://cloud.githubusercontent.com/assets/448516/8338798/10f8f2f4-1a68-11e5-8d50-cf0d8e516929.png">


/cc @maddox