### PR TITLE
Allow user to disable auto data uri whitelist

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -128,6 +128,7 @@ module SecureHeaders
 
       @disable_fill_missing = !!@config.delete(:disable_fill_missing)
       @enforce = !!@config.delete(:enforce)
+      @disable_img_src_data_uri = !!@config.delete(:disable_img_src_data_uri)
       @tag_report_uri = !!@config.delete(:tag_report_uri)
       @script_hashes = @config.delete(:script_hashes) || []
 
@@ -238,10 +239,11 @@ module SecureHeaders
 
     def generic_directives
       header_value = ''
+      data_uri = @disable_img_src_data_uri ? [] : ["data:"]
       if @config[:img_src]
-        @config[:img_src] = @config[:img_src] + ['data:'] unless @config[:img_src].include?('data:')
+        @config[:img_src] = @config[:img_src] + data_uri unless @config[:img_src].include?('data:')
       else
-        @config[:img_src] = @config[:default_src] + ['data:']
+        @config[:img_src] = @config[:default_src] + data_uri
       end
 
       DIRECTIVES.each do |directive_name|

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -156,6 +156,16 @@ module SecureHeaders
           csp = ContentSecurityPolicy.new({:default_src => 'self', :img_src => 'self', :disable_fill_missing => true}, :request => request_for(CHROME))
           expect(csp.value).to eq("default-src 'self'; img-src 'self' data:;")
         end
+
+        it "doesn't add a duplicate data uri if img-src specifies it already" do
+          csp = ContentSecurityPolicy.new({:default_src => 'self', :img_src => 'self data:', :disable_fill_missing => true}, :request => request_for(CHROME))
+          expect(csp.value).to eq("default-src 'self'; img-src 'self' data:;")
+        end
+
+        it "allows the user to disable img-src data: uris auto-whitelisting" do
+          csp = ContentSecurityPolicy.new({:default_src => 'self', :img_src => 'self', :disable_img_src_data_uri => true, :disable_fill_missing => true}, :request => request_for(CHROME))
+          expect(csp.value).to eq("default-src 'self'; img-src 'self';")
+        end
       end
 
       it "fills in directives without values with default-src value" do


### PR DESCRIPTION
The current behavior results in a data URI being appended to the ```img-src``` directive regardless of whether or not the user actually wants to allow data URIs. This PR introduced a new configuration option that the user can specify in order to disable the auto-whitelisting.