### PR TITLE
Fixed a small typo in the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ end
 
 * Node.js (express) [helmet](https://github.com/evilpacket/helmet) and [hood](https://github.com/seanmonstar/hood)
 * Node.js (hapi) [blankie](https://github.com/nlf/blankie)
-* J2EE Servlet >= 3.0 [highlines](https://github.com/sourceclear/headlines)
+* J2EE Servlet >= 3.0 [headlines](https://github.com/sourceclear/headlines)
 * ASP.NET - [NWebsec](https://github.com/NWebsec/NWebsec/wiki)
 * Python - [django-csp](https://github.com/mozilla/django-csp) + [commonware](https://github.com/jsocol/commonware/); [django-security](https://github.com/sdelements/django-security)
 * Go - [secureheader](https://github.com/kr/secureheader)


### PR DESCRIPTION
I just fixed a small typo in the README.md file for the name of our library.