### PR TITLE
Fixed typographical error, changed authorites to authorities in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The gem will automatically apply several headers that are related to security.  
 - X-Content-Type-Options - [Prevent content type sniffing](http://msdn.microsoft.com/en-us/library/ie/gg622941\(v=vs.85\).aspx)
 - X-Download-Options - [Prevent file downloads opening](http://msdn.microsoft.com/en-us/library/ie/jj542450(v=vs.85).aspx)
 - X-Permitted-Cross-Domain-Policies - [Restrict Adobe Flash Player's access to data](https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html)
-- Public Key Pinning - Pin certificate fingerprints in the browser to prevent man-in-the-middle attacks due to compromised Certificate Authorites. [Public Key Pinnning  Specification](https://tools.ietf.org/html/rfc7469)
+- Public Key Pinning - Pin certificate fingerprints in the browser to prevent man-in-the-middle attacks due to compromised Certificate Authorities. [Public Key Pinnning  Specification](https://tools.ietf.org/html/rfc7469)
 
 ## Usage
 


### PR DESCRIPTION
@twitter, I've corrected a typographical error in the documentation of the [secureheaders](https://github.com/twitter/secureheaders) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.