### PR TITLE
Remove the 'fill missing directives with default-src value' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,6 @@ The following methods are going to be called, unless they are provided in a `ski
 * `:set_x_download_options_header`
 * `:set_x_permitted_cross_domain_policies_header`
 
-### Bonus Features
-
-This gem makes a few assumptions about how you will use some features.  For example:
-
-* It fills any blank directives with the value in `:default_src`  Getting a default\-src report is pretty useless.  This way, you will always know what type of violation occurred. You can disable this feature by supplying `:disable_fill_missing => true`. This is referred to as the "effective-directive" in the spec, but is not well supported as of Nov 5, 2013.
-
 ## Configuration
 
 **Place the following in an initializer (recommended):**

--- a/fixtures/rails_3_2_22/config/initializers/secure_headers.rb
+++ b/fixtures/rails_3_2_22/config/initializers/secure_headers.rb
@@ -7,7 +7,6 @@
   csp = {
     :default_src => "self",
     :script_src => "self nonce",
-    :disable_fill_missing => true,
     :report_uri => 'somewhere',
     :script_hash_middleware => true,
     :enforce => false # false means warnings only

--- a/fixtures/rails_3_2_22_no_init/app/controllers/other_things_controller.rb
+++ b/fixtures/rails_3_2_22_no_init/app/controllers/other_things_controller.rb
@@ -1,5 +1,5 @@
 class OtherThingsController < ApplicationController
-  ensure_security_headers :csp => {:default_src => 'self', :disable_fill_missing => true}
+  ensure_security_headers :csp => {:default_src => 'self'}
   def index
 
   end

--- a/fixtures/rails_4_1_8/config/initializers/secure_headers.rb
+++ b/fixtures/rails_4_1_8/config/initializers/secure_headers.rb
@@ -7,7 +7,6 @@
   csp = {
     :default_src => "self",
     :script_src => "self nonce",
-    :disable_fill_missing => true,
     :report_uri => 'somewhere',
     :script_hash_middleware => true,
     :enforce => false # false means warnings only

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -45,8 +45,7 @@ module SecureHeaders
 
     include Constants
 
-    attr_reader :disable_fill_missing, :ssl_request
-    alias :disable_fill_missing? :disable_fill_missing
+    attr_reader :ssl_request
     alias :ssl_request? :ssl_request
 
     class << self
@@ -128,15 +127,12 @@ module SecureHeaders
       @http_additions = @config.delete(:http_additions)
       @app_name = @config.delete(:app_name)
       @report_uri = @config.delete(:report_uri)
-
-      @disable_fill_missing = !!@config.delete(:disable_fill_missing)
       @enforce = !!@config.delete(:enforce)
       @disable_img_src_data_uri = !!@config.delete(:disable_img_src_data_uri)
       @tag_report_uri = !!@config.delete(:tag_report_uri)
       @script_hashes = @config.delete(:script_hashes) || []
 
       add_script_hashes if @script_hashes.any?
-      fill_directives unless disable_fill_missing?
     end
 
     ##
@@ -198,16 +194,6 @@ module SecureHeaders
         non_default_directives,
         report_uri_directive
       ].join.strip
-    end
-
-    def fill_directives
-      if default = @config[:default_src]
-        DIRECTIVES.each do |directive|
-          unless @config[directive]
-            @config[directive] = default
-          end
-        end
-      end
     end
 
     def append_http_additions


### PR DESCRIPTION
1. This should not be required since browsers should implement the `effective-directive` portion of the spec.
1. Managing what is considered an inherited value for the various browser versions can get tricky (see https://github.com/twitter/secureheaders/issues/170).
1. It's not that hard to do the same thing manually
1. It somewhat encourages lazy, over permissive policies.