### PR TITLE
remove examples that use inline/eval over 'unsafe-inline'/'unsafe-eval'

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This configuration will likely work for most applications without modification.
 ```ruby
 # most basic example
 :csp => {
-  :default_src => "https: inline eval",
+  :default_src => "https: 'unsafe-inline' 'unsafe-eval'",
   :report_uri => '/uri-directive'
 }
 

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -220,9 +220,10 @@ module SecureHeaders
 
     def translate_dir_value val
       if %w{inline eval}.include?(val)
+        warn "[DEPRECATION] using inline/eval may not be supported in the future. Instead use 'unsafe-inline'/'unsafe-eval' instead."
         val == 'inline' ? "'unsafe-inline'" : "'unsafe-eval'"
-        # self/none are special sources/src-dir-values and need to be quoted
       elsif %{self none}.include?(val)
+        warn "[DEPRECATION] using self/none may not be supported in the future. Instead use 'self'/'none' instead."
         "'#{val}'"
       elsif val == 'nonce'
         if supports_nonces?(@ua)

--- a/spec/lib/secure_headers/headers/content_security_policy/script_hash_middleware_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy/script_hash_middleware_spec.rb
@@ -13,8 +13,8 @@ module SecureHeaders
         :disable_fill_missing => true,
         :default_src => 'https://*',
         :report_uri => '/csp_report',
-        :script_src => 'inline eval https://* data:',
-        :style_src => "inline https://* about:"
+        :script_src => "'unsafe-inline' 'unsafe-eval' https://* data:",
+        :style_src => "'unsafe-inline' https://* about:"
       }
     end
 

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -7,8 +7,8 @@ module SecureHeaders
         :disable_fill_missing => true,
         :default_src => 'https:',
         :report_uri => '/csp_report',
-        :script_src => 'inline eval https: data:',
-        :style_src => "inline https: about:"
+        :script_src => "'unsafe-inline' 'unsafe-eval' https: data:",
+        :style_src => "'unsafe-inline' https: about:"
       }
     end
     let(:controller) { DummyClass.new }
@@ -254,7 +254,7 @@ module SecureHeaders
         end
 
         it "does not add 'unsafe-inline' twice" do
-          header = ContentSecurityPolicy.new(default_opts.merge(:script_src => "self nonce inline"), :request => request_for(CHROME), :controller => controller)
+          header = ContentSecurityPolicy.new(default_opts.merge(:script_src => "self nonce 'unsafe-inline'"), :request => request_for(CHROME), :controller => controller)
           expect(header.value).to include("script-src 'self' 'nonce-#{header.nonce}' 'unsafe-inline';")
         end
       end

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -127,7 +127,7 @@ describe SecureHeaders do
 
     it "saves the options to the env when using script hashes" do
       opts = {
-        :default_src => 'self',
+        :default_src => "'self'",
         :script_hash_middleware => true
       }
       stub_user_agent(USER_AGENTS[:chrome])
@@ -166,7 +166,7 @@ describe SecureHeaders do
     end
 
     it "produces a hash of headers given a hash as config" do
-      hash = SecureHeaders::header_hash(:csp => {:default_src => 'none', :img_src => "data:", :disable_fill_missing => true})
+      hash = SecureHeaders::header_hash(:csp => {:default_src => "'none'", :img_src => "data:", :disable_fill_missing => true})
       expect(hash['Content-Security-Policy-Report-Only']).to eq("default-src 'none'; img-src data:;")
       expect_default_values(hash)
     end
@@ -186,7 +186,7 @@ describe SecureHeaders do
         }
       end
 
-      hash = SecureHeaders::header_hash(:csp => {:default_src => 'none', :img_src => "data:", :disable_fill_missing => true})
+      hash = SecureHeaders::header_hash(:csp => {:default_src => "'none'", :img_src => "data:", :disable_fill_missing => true})
       ::SecureHeaders::Configuration.configure do |config|
         config.hsts = nil
         config.hpkp = nil


### PR DESCRIPTION
Fixes https://github.com/twitter/secureheaders/issues/169

Adds a deprecation warning too. 