### PR TITLE
Ua sniffing for support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem 'pry'
   gem 'test-unit', '~> 3.0'
   gem 'rails', '3.2.22'
   gem 'sqlite3', :platforms => [:ruby, :mswin, :mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'pry'
   gem 'test-unit', '~> 3.0'
   gem 'rails', '3.2.22'
   gem 'sqlite3', :platforms => [:ruby, :mswin, :mingw]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The following methods are going to be called, unless they are provided in a `ski
     :form_action => "'self' github.com",
     :frame_ancestors => "'none'",
     :plugin_types => 'application/x-shockwave-flash',
+    :block_all_mixed_content => '' # see [http://www.w3.org/TR/mixed-content/]()
     :report_uri => '//example.com/uri-directive'
   }
   config.hpkp = {
@@ -99,7 +100,7 @@ Sometimes you need to override your content security policy for a given endpoint
 1. Override the `secure_header_options_for` class instance method. e.g.
 
 ```ruby
-class SomethingController < ApplicationController 
+class SomethingController < ApplicationController
   def wumbus
     # gets style-src override
   end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -28,7 +28,7 @@ module SecureHeaders
 
       DIRECTIVES_2_0 = [
         DIRECTIVES_1_0,
-        :base_url,
+        :base_uri,
         :child_src,
         :form_action,
         :frame_ancestors,

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -66,7 +66,7 @@ module SecureHeaders
         DIRECTIVES_2_0 + DIRECTIVES_DRAFT
       ).freeze
 
-      ALL_DIRECTIVES = [DIRECTIVES_1_0 + DIRECTIVES_2_0 + DIRECTIVES_3_0 + DIRECTIVES_DRAFT].flatten.sort.uniq
+      ALL_DIRECTIVES = [DIRECTIVES_1_0 + DIRECTIVES_2_0 + DIRECTIVES_3_0 + DIRECTIVES_DRAFT].flatten.uniq.sort
       CONFIG_KEY = :csp
     end
 

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -68,6 +68,7 @@ module SecureHeaders
       ).freeze
 
       ALL_DIRECTIVES = [DIRECTIVES_1_0 + DIRECTIVES_2_0 + DIRECTIVES_3_0 + DIRECTIVES_DRAFT].flatten.sort.uniq
+      ALL_CONFIGS = [:enforce, :app_name, :script_hash_middleware] + ALL_DIRECTIVES
       CONFIG_KEY = :csp
     end
 
@@ -147,7 +148,7 @@ module SecureHeaders
       # Config values can be string, array, or lamdba values
       @config = config.inject({}) do |hash, (key, value)|
         config_val = value.respond_to?(:call) ? value.call(@controller) : value
-        if ([:enforce, :app_name] + ContentSecurityPolicy::ALL_DIRECTIVES).include?(key.to_sym) # directives need to be normalized to arrays of strings
+        if ContentSecurityPolicy::ALL_CONFIGS.include?(key.to_sym) # directives need to be normalized to arrays of strings
           config_val = config_val.split if config_val.is_a? String
           if config_val.is_a?(Array)
             config_val = config_val.map do |val|

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -67,7 +67,7 @@ module SecureHeaders
         DIRECTIVES_2_0 + DIRECTIVES_DRAFT
       ).freeze
 
-      ALL_DIRECTIVES = [DIRECTIVES_1_0 + DIRECTIVES_2_0 + DIRECTIVES_3_0 + DIRECTIVES_DRAFT].flatten.uniq
+      ALL_DIRECTIVES = [DIRECTIVES_1_0 + DIRECTIVES_2_0 + DIRECTIVES_3_0 + DIRECTIVES_DRAFT].flatten.sort.uniq
       CONFIG_KEY = :csp
     end
 
@@ -274,8 +274,9 @@ module SecureHeaders
       end
     end
 
+    # ensures defualt_src is first and report_uri is last
     def generic_directives
-      header_value = ''
+      header_value = build_directive(:default_src)
       data_uri = @disable_img_src_data_uri ? [] : ["data:"]
       if @config[:img_src]
         @config[:img_src] = @config[:img_src] + data_uri unless @config[:img_src].include?('data:')
@@ -283,11 +284,13 @@ module SecureHeaders
         @config[:img_src] = @config[:default_src] + data_uri
       end
 
-      ALL_DIRECTIVES.each do |directive_name|
+      (ALL_DIRECTIVES - [:default_src, :report_uri]).each do |directive_name|
         if @config[directive_name]
           header_value += build_directive(directive_name)
         end
       end
+
+      header_value += build_directive(:report_uri) if @config[:report_uri]
 
       header_value.strip
     end

--- a/lib/secure_headers/view_helper.rb
+++ b/lib/secure_headers/view_helper.rb
@@ -27,7 +27,6 @@ module SecureHeaders
           if raise_error_on_unrecognized_hash
             raise UnexpectedHashedScriptException.new(message)
           else
-            puts message
             request.env[HASHES_ENV_KEY] = (request.env[HASHES_ENV_KEY] || []) << hash_value
           end
         end

--- a/spec/lib/secure_headers/headers/content_security_policy/script_hash_middleware_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy/script_hash_middleware_spec.rb
@@ -10,7 +10,6 @@ module SecureHeaders
 
     let(:default_config) do
       {
-        :disable_fill_missing => true,
         :default_src => 'https://*',
         :report_uri => '/csp_report',
         :script_src => "'unsafe-inline' 'unsafe-eval' https://* data:",

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -250,7 +250,7 @@ module SecureHeaders
 
         it "adds directive values for headers on http" do
           csp = ContentSecurityPolicy.new(options, :request => request_for(CHROME))
-          expect(csp.value).to eq("default-src https:; frame-src http:; img-src http: data:; script-src 'unsafe-inline' 'unsafe-eval' https: data:; style-src 'unsafe-inline' https: about:; report-uri /csp_report;")
+          expect(csp.value).to eq("default-src https:; frame-src http:; img-src https: data: http:; script-src 'unsafe-inline' 'unsafe-eval' https: data:; style-src 'unsafe-inline' https: about:; report-uri /csp_report;")
         end
 
         it "does not add the directive values if requesting https" do

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -149,15 +149,15 @@ module SecureHeaders
 
         it "does not filter any directives for Chrome" do
           policy = ContentSecurityPolicy.new(complex_opts, :request => request_for(CHROME))
-          expect(policy.value).to eq("default-src 'self'; base-url 'self'; block-all-mixed-content ; child-src 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; img-src 'self' data:; media-src 'self'; object-src 'self'; plugin-types 'self'; sandbox 'self'; script-src 'self'; style-src 'self'; report-uri 'self';")
+          expect(policy.value).to eq("default-src 'self'; base-uri 'self'; block-all-mixed-content ; child-src 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; img-src 'self' data:; media-src 'self'; object-src 'self'; plugin-types 'self'; sandbox 'self'; script-src 'self'; style-src 'self'; report-uri 'self';")
         end
 
         it "filters blocked-all-mixed-content, child-src, and plugin-types for firefox" do
           policy = ContentSecurityPolicy.new(complex_opts, :request => request_for(FIREFOX))
-          expect(policy.value).to eq("default-src 'self'; base-url 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; img-src 'self' data:; media-src 'self'; object-src 'self'; sandbox 'self'; script-src 'self'; style-src 'self'; report-uri 'self';")
+          expect(policy.value).to eq("default-src 'self'; base-uri 'self'; connect-src 'self'; font-src 'self'; form-action 'self'; frame-ancestors 'self'; frame-src 'self'; img-src 'self' data:; media-src 'self'; object-src 'self'; sandbox 'self'; script-src 'self'; style-src 'self'; report-uri 'self';")
         end
 
-        it "filters base-url, blocked-all-mixed-content, child-src, form-action, frame-ancestors, and plugin-types for safari" do
+        it "filters base-uri, blocked-all-mixed-content, child-src, form-action, frame-ancestors, and plugin-types for safari" do
           policy = ContentSecurityPolicy.new(complex_opts, :request => request_for(SAFARI))
           expect(policy.value).to eq("default-src 'self'; connect-src 'self'; font-src 'self'; frame-src 'self'; img-src 'self' data:; media-src 'self'; object-src 'self'; sandbox 'self'; script-src 'self'; style-src 'self'; report-uri 'self';")
         end

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -59,7 +59,6 @@ module SecureHeaders
 
     it "exports a policy to JSON" do
       policy = ContentSecurityPolicy.new(default_opts)
-      puts default_opts
       expected = %({"default-src":["https:"],"img-src":["https:","data:"],"script-src":["'unsafe-inline'","'unsafe-eval'","https:","data:"],"style-src":["'unsafe-inline'","https:","about:"],"report-uri":["/csp_report"]})
       expect(policy.to_json).to eq(expected)
     end

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -5,9 +5,10 @@ module SecureHeaders
     let(:default_opts) do
       {
         :default_src => 'https:',
-        :report_uri => '/csp_report',
+        :img_src => "https: data:",
         :script_src => "'unsafe-inline' 'unsafe-eval' https: data:",
-        :style_src => "'unsafe-inline' https: about:"
+        :style_src => "'unsafe-inline' https: about:",
+        :report_uri => '/csp_report'
       }
     end
     let(:controller) { DummyClass.new }
@@ -58,7 +59,8 @@ module SecureHeaders
 
     it "exports a policy to JSON" do
       policy = ContentSecurityPolicy.new(default_opts)
-      expected = %({"default-src":["https:"],"script-src":["'unsafe-inline'","'unsafe-eval'","https:","data:"],"style-src":["'unsafe-inline'","https:","about:"],"img-src":["https:","data:"]})
+      puts default_opts
+      expected = %({"default-src":["https:"],"img-src":["https:","data:"],"script-src":["'unsafe-inline'","'unsafe-eval'","https:","data:"],"style-src":["'unsafe-inline'","https:","about:"],"report-uri":["/csp_report"]})
       expect(policy.to_json).to eq(expected)
     end
 

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -166,7 +166,7 @@ describe SecureHeaders do
     end
 
     it "produces a hash of headers given a hash as config" do
-      hash = SecureHeaders::header_hash(:csp => {:default_src => "'none'", :img_src => "data:", :disable_fill_missing => true})
+      hash = SecureHeaders::header_hash(:csp => {:default_src => "'none'", :img_src => "data:"})
       expect(hash['Content-Security-Policy-Report-Only']).to eq("default-src 'none'; img-src data:;")
       expect_default_values(hash)
     end
@@ -186,7 +186,7 @@ describe SecureHeaders do
         }
       end
 
-      hash = SecureHeaders::header_hash(:csp => {:default_src => "'none'", :img_src => "data:", :disable_fill_missing => true})
+      hash = SecureHeaders::header_hash(:csp => {:default_src => "'none'", :img_src => "data:"})
       ::SecureHeaders::Configuration.configure do |config|
         config.hsts = nil
         config.hpkp = nil


### PR DESCRIPTION
Integrating the browser sniffing / directive use that GitHub uses internally. Use the UA to determine which directives should be supported. Provides better validation of config values.