### PR TITLE
fix regression with mutation of global state

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -133,15 +133,6 @@ module SecureHeaders
       @ua = options[:ua]
       @ssl_request = !!options.delete(:ssl)
       @request_uri = options.delete(:request_uri)
-      @http_additions = config.delete(:http_additions)
-      @disable_img_src_data_uri = !!config.delete(:disable_img_src_data_uri)
-      @tag_report_uri = !!config.delete(:tag_report_uri)
-      @script_hashes = config.delete(:script_hashes) || []
-      @app_name = config.delete(:app_name)
-      @app_name = @app_name.call(@controller) if @app_name.respond_to?(:call)
-      @enforce = config.delete(:enforce)
-      @enforce = @enforce.call(@controller) if @enforce.respond_to?(:call)
-      @enforce = !!@enforce
 
       # Config values can be string, array, or lamdba values
       @config = config.inject({}) do |hash, (key, value)|
@@ -153,13 +144,21 @@ module SecureHeaders
               translate_dir_value(val)
             end.flatten.uniq
           end
-        elsif key != :script_hash_middleware
-          raise ArgumentError.new("Unknown directive supplied: #{key}")
         end
 
         hash[key] = config_val
         hash
       end
+
+      @http_additions = @config.delete(:http_additions)
+      @disable_img_src_data_uri = !!@config.delete(:disable_img_src_data_uri)
+      @tag_report_uri = !!@config.delete(:tag_report_uri)
+      @script_hashes = @config.delete(:script_hashes) || []
+      @app_name = @config.delete(:app_name)
+      @app_name = @app_name.call(@controller) if @app_name.respond_to?(:call)
+      @enforce = @config.delete(:enforce)
+      @enforce = @enforce.call(@controller) if @enforce.respond_to?(:call)
+      @enforce = !!@enforce
 
       # normalize and tag the report-uri
       if @config[:report_uri]

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -142,6 +142,14 @@ module SecureHeaders
     end
 
     describe "#value" do
+      it "does not mutate shared state" do
+        opts = default_opts.merge(enforce: true)
+        policy = ContentSecurityPolicy.new(opts, :request => request_for(CHROME))
+        expect(policy.name).to eq("Content-Security-Policy")
+        policy = ContentSecurityPolicy.new(opts, :request => request_for(CHROME))
+        expect(policy.name).to eq("Content-Security-Policy")
+      end
+
       context "browser sniffing" do
         let(:complex_opts) do
           ALL_DIRECTIVES.inject({}) { |memo, directive| memo[directive] = "'self'"; memo }.merge(:block_all_mixed_content => '')


### PR DESCRIPTION
In an attempt to perform strict validation on the values passed into secureheaders configs, I forgot that I was mutating global state.

Fixes #183 