### PR TITLE
2.x deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ rvm:
 
 sudo: false
 cache: bundler
+before_install: gem update bundler

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem "guard-rspec", platforms: [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
   gem 'test-unit', '~> 3.0'
   gem 'rails', '3.2.22'
   gem 'sqlite3', :platforms => [:ruby, :mswin, :mingw]

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,12 @@
+guard :rspec, cmd: "bundle exec rspec", all_on_start: true, all_after_pass: true do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  watch(%r{^lib/(.+)\.rb$}) { |m| "spec/lib/#{m[1]}_spec.rb" }
+end

--- a/fixtures/rails_3_2_22_no_init/app/controllers/other_things_controller.rb
+++ b/fixtures/rails_3_2_22_no_init/app/controllers/other_things_controller.rb
@@ -9,6 +9,7 @@ class OtherThingsController < ApplicationController
   end
 
   def secure_header_options_for(header, options)
+    warn "[DEPRECATION] secure_header_options_for will not be supported in secure_headers 3.x."
     if params[:action] == "other_action"
       if header == :csp
         options.merge(:style_src => "'self'")

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -33,11 +33,17 @@ module SecureHeaders
         :x_xss_protection, :csp, :x_download_options, :script_hashes,
         :x_permitted_cross_domain_policies, :hpkp
 
-      def configure &block
+      # For preparation for the secure_headers 3.x change.
+      def default &block
         instance_eval &block
         if File.exists?(SCRIPT_HASH_CONFIG_FILE)
           ::SecureHeaders::Configuration.script_hashes = YAML.load(File.open(SCRIPT_HASH_CONFIG_FILE))
         end
+      end
+
+      def configure &block
+        warn "[DEPRECATION] `configure` is removed in secure_headers 3.x. Instead use `default`."
+        default &block
       end
     end
   end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -139,7 +139,10 @@ module SecureHeaders
       @config = config.inject({}) do |hash, (key, value)|
         config_val = value.respond_to?(:call) ? value.call(@controller) : value
         if ALL_DIRECTIVES.include?(key.to_sym) # directives need to be normalized to arrays of strings
-          config_val = config_val.split if config_val.is_a? String
+          if config_val.is_a? String
+            warn "[DEPRECATION] A String was supplied for directive #{key}. secure_headers 3.x will require all directives to be arrays of strings."
+            config_val = config_val.split
+          end
           if config_val.is_a?(Array)
             config_val = config_val.map do |val|
               translate_dir_value(val)

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -261,10 +261,10 @@ module SecureHeaders
 
     def translate_dir_value val
       if %w{inline eval}.include?(val)
-        warn "[DEPRECATION] using inline/eval may not be supported in the future. Instead use 'unsafe-inline'/'unsafe-eval' instead."
+        warn "[DEPRECATION] using inline/eval is not suppored in secure_headers 3.x. Instead use 'unsafe-inline'/'unsafe-eval' instead."
         val == 'inline' ? "'unsafe-inline'" : "'unsafe-eval'"
       elsif %{self none}.include?(val)
-        warn "[DEPRECATION] using self/none may not be supported in the future. Instead use 'self'/'none' instead."
+        warn "[DEPRECATION] using self/none is not suppored in secure_headers 3.x. Instead use 'self'/'none' instead."
         "'#{val}'"
       elsif val == 'nonce'
         if supports_nonces?

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -137,7 +137,13 @@ module SecureHeaders
 
       # Config values can be string, array, or lamdba values
       @config = config.inject({}) do |hash, (key, value)|
-        config_val = value.respond_to?(:call) ? value.call(@controller) : value
+        config_val = if value.respond_to?(:call)
+          warn "[DEPRECATION] secure_headers 3.x will not support procs as config values."
+          value.call(@controller)
+        else
+          value
+        end
+
         if ALL_DIRECTIVES.include?(key.to_sym) # directives need to be normalized to arrays of strings
           if config_val.is_a? String
             warn "[DEPRECATION] A String was supplied for directive #{key}. secure_headers 3.x will require all directives to be arrays of strings."

--- a/lib/secure_headers/headers/strict_transport_security.rb
+++ b/lib/secure_headers/headers/strict_transport_security.rb
@@ -41,6 +41,7 @@ module SecureHeaders
 
     def validate_config
       if @config.is_a? Hash
+        warn "[DEPRECATION] secure_headers 3.0 will only accept string values for StrictTransportSecurity config"
         if !@config[:max_age]
           raise STSBuildError.new("No max-age was supplied.")
         elsif @config[:max_age].to_s !~ /\A\d+\z/

--- a/lib/secure_headers/headers/x_content_type_options.rb
+++ b/lib/secure_headers/headers/x_content_type_options.rb
@@ -25,6 +25,7 @@ module SecureHeaders
       when String
         @config
       else
+        warn "[DEPRECATION] secure_headers 3.0 will only accept string values for XContentTypeOptions config"
         @config[:value]
       end
     end

--- a/lib/secure_headers/headers/x_download_options.rb
+++ b/lib/secure_headers/headers/x_download_options.rb
@@ -24,6 +24,7 @@ module SecureHeaders
       when String
         @config
       else
+        warn "[DEPRECATION] secure_headers 3.0 will only accept string values for XDownloadOptions config"
         @config[:value]
       end
     end

--- a/lib/secure_headers/headers/x_frame_options.rb
+++ b/lib/secure_headers/headers/x_frame_options.rb
@@ -25,6 +25,7 @@ module SecureHeaders
       when String
         @config
       else
+        warn "[DEPRECATION] secure_headers 3.0 will only accept string values for XFrameOptions config"
         @config[:value]
       end
     end

--- a/lib/secure_headers/headers/x_permitted_cross_domain_policies.rb
+++ b/lib/secure_headers/headers/x_permitted_cross_domain_policies.rb
@@ -25,6 +25,7 @@ module SecureHeaders
       when String
         @config
       else
+        warn "[DEPRECATION] secure_headers 3.0 will only accept string values for XPermittedCrossDomainPolicies config"
         @config[:value]
       end
     end

--- a/lib/secure_headers/headers/x_xss_protection.rb
+++ b/lib/secure_headers/headers/x_xss_protection.rb
@@ -25,6 +25,7 @@ module SecureHeaders
       when String
         @config
       else
+        warn "[DEPRECATION] secure_headers 3.0 will only accept string values for XXssProtection config"
         value = @config[:value].to_s
         value += "; mode=#{@config[:mode]}" if @config[:mode]
         value += "; report=#{@config[:report_uri]}" if @config[:report_uri]

--- a/lib/secure_headers/version.rb
+++ b/lib/secure_headers/version.rb
@@ -1,3 +1,3 @@
 module SecureHeaders
-  VERSION = "2.4.4"
+  VERSION = "2.5.0"
 end

--- a/secure_headers.gemspec
+++ b/secure_headers.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.add_development_dependency "rake"
   gem.add_dependency "user_agent_parser"
+  gem.post_install_message = "[DEPRECATION] Development has stopped on the 2.x line of secure_headers. It will be maintained, but new features will be added to the 3.x branch. A lot has changed in secure_headers 3.x. A migration guide can be found in the documentation: https://github.com/twitter/secureheaders/blob/master/upgrading-to-3-0.md."
 end

--- a/spec/lib/secure_headers/headers/x_content_type_options_spec.rb
+++ b/spec/lib/secure_headers/headers/x_content_type_options_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 module SecureHeaders
   describe XContentTypeOptions do
     specify{ expect(XContentTypeOptions.new.name).to eq("X-Content-Type-Options") }

--- a/spec/lib/secure_headers/headers/x_xss_protection_spec.rb
+++ b/spec/lib/secure_headers/headers/x_xss_protection_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 module SecureHeaders
   describe XXssProtection do
     specify { expect(XXssProtection.new.name).to eq(X_XSS_PROTECTION_HEADER_NAME)}

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -20,7 +20,7 @@ describe SecureHeaders do
   end
 
   def reset_config
-    ::SecureHeaders::Configuration.configure do |config|
+    ::SecureHeaders::Configuration.default do |config|
       config.hpkp = nil
       config.hsts = nil
       config.x_frame_options = nil
@@ -139,7 +139,7 @@ describe SecureHeaders do
 
     context "when disabled by configuration settings" do
       it "does not set any headers when disabled" do
-        ::SecureHeaders::Configuration.configure do |config|
+        ::SecureHeaders::Configuration.default do |config|
           config.hsts = false
           config.hpkp = false
           config.x_frame_options = false
@@ -179,7 +179,7 @@ describe SecureHeaders do
     end
 
     it "allows opting out with config" do
-      ::SecureHeaders::Configuration.configure do |config|
+      ::SecureHeaders::Configuration.default do |config|
         config.hsts = false
         config.csp = false
       end
@@ -190,7 +190,7 @@ describe SecureHeaders do
     end
 
     it "produces a hash with a mix of config values, override values, and default values" do
-      ::SecureHeaders::Configuration.configure do |config|
+      ::SecureHeaders::Configuration.default do |config|
         config.hsts = { :max_age => '123456'}
         config.hpkp = {
           :enforce => true,
@@ -205,7 +205,7 @@ describe SecureHeaders do
       end
 
       hash = SecureHeaders::header_hash(:csp => {:default_src => "'none'", :img_src => "data:"})
-      ::SecureHeaders::Configuration.configure do |config|
+      ::SecureHeaders::Configuration.default do |config|
         config.hsts = nil
         config.hpkp = nil
       end


### PR DESCRIPTION
Update the 2.x branch with deprecation warnings for upgrading to the 3.x branch. 

Lots of things will break with the new major release, almost all of which should be covered by these deprecation warnings. A post install message provides a link to the migration document: https://github.com/twitter/secureheaders/blob/master/upgrading-to-3-0.md

This _should_ cover everything and these changes should be forward compatible with 3.x.