### PR TITLE
If a policy modification is idempotent, don't dup the config

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -181,7 +181,7 @@ module SecureHeaders
       # because google.com is already in the config.
       def idempotent_additions?(config, additions)
         return false if config == OPT_OUT
-        config == combine_policies(config, additions)
+        config.to_s == combine_policies(config, additions).to_s
       end
 
       # Public: combine the values from two different configs.

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -213,11 +213,11 @@ module SecureHeaders
         # when each hash contains a value for a given key.
         original.merge(additions) do |directive, lhs, rhs|
           if source_list?(directive)
-            lhs | rhs
+            (lhs.to_a + rhs).uniq.compact
           else
             rhs
           end
-        end
+        end.reject { |_, value| value.nil? || value == [] } # this mess prevents us from adding empty directives.
       end
 
       private

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -157,13 +157,7 @@ module SecureHeaders
         [header.name, header.value]
       end
 
-      # Public: Validates that the configuration has a valid type, or that it is a valid
-      # source expression.
-      #
-      # Private: validates that a source expression:
-      # 1. has a valid name
-      # 2. is an array of strings
-      # 3. does not contain any depreated, now invalid values (inline, eval, self, none)
+      # Public: Validates each source expression.
       #
       # Does not validate the invididual values of the source expression (e.g.
       # script_src => h*t*t*p: will not raise an exception)
@@ -177,6 +171,17 @@ module SecureHeaders
             validate_directive!(key, value)
           end
         end
+      end
+
+      # Public: determine if merging +additions+ will cause a change to the
+      # actual value of the config.
+      #
+      # e.g. config = { script_src: %w(example.org google.com)} and
+      # additions = { script_src: %w(google.com)} then idempotent_additions? would return
+      # because google.com is already in the config.
+      def idempotent_additions?(config, additions)
+        return false if config == OPT_OUT
+        config == combine_policies(config, additions)
       end
 
       # Public: combine the values from two different configs.

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -109,6 +109,16 @@ module SecureHeaders
       end
     end
 
+    describe "#idempotent_additions?" do
+      specify { expect(ContentSecurityPolicy.idempotent_additions?(OPT_OUT, script_src: %w(b.com))).to be false }
+      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w(c.com))).to be false }
+      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, style_src: %w(b.com))).to be false }
+      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w(a.com b.com c.com))).to be false }
+
+      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w(b.com))).to be true }
+      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w(b.com a.com))).to be true }
+    end
+
     describe "#value" do
       it "discards 'none' values if any other source expressions are present" do
         csp = ContentSecurityPolicy.new(default_opts.merge(frame_src: %w('self' 'none')))

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -117,6 +117,9 @@ module SecureHeaders
 
       specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w(b.com))).to be true }
       specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w(b.com a.com))).to be true }
+      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w())).to be true }
+      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: [nil])).to be true }
+      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, style_src: [nil])).to be true }
     end
 
     describe "#value" do


### PR DESCRIPTION
This adds the `#idempotent_additions?` method to the CSP class for determining whether `config` will change at all after `additions` are merged into the config. 

The `override/append_content_security_policy_directive` methods are wrapped in a call to `idempotent_additions?` before the configuration object is modified. Modifying the configuration object causes it to discard the precomputed header values. If the change has no effect, then there's no reason to blow away the cache.