### PR TITLE
Add CSP config flag to preserve host source schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The gem will automatically apply several headers that are related to security.  
 
 If you do not supply a `default` configuration, exceptions will be raised. If you would like to use a default configuration (which is fairly locked down), just call `SecureHeaders::Configuration.default` without any arguments or block.
 
-All `nil` values will fallback to their default value. `SecureHeaders::OPT_OUT` will disable the header entirely.
+All `nil` values will fallback to their default values. `SecureHeaders::OPT_OUT` will disable the header entirely.
 
 ```ruby
 SecureHeaders::Configuration.default do |config|
@@ -36,8 +36,12 @@ SecureHeaders::Configuration.default do |config|
   config.x_download_options = "noopen"
   config.x_permitted_cross_domain_policies = "none"
   config.csp = {
+    # "meta" values. these will shaped the header, but the values are not included in the header.
+    report_only:  true,    # default: false
+    preserve_schemes: true # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
+
+    # directive values: these values will directly translate into source directives
     default_src: %w(https: 'self'),
-    report_only: false,
     frame_src: %w('self' *.twimg.com itunes.apple.com),
     connect_src: %w(wws:),
     font_src: %w('self' data:),

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -275,7 +275,8 @@ module SecureHeaders
       else
         UserAgent.parse(user_agent)
       end
-      @report_only = !!@config[:report_only]
+      @report_only = @config[:report_only]
+      @preserve_schemes = @config[:preserve_schemes]
       @script_nonce = @config[:script_nonce]
       @style_nonce = @config[:style_nonce]
     end
@@ -345,9 +346,12 @@ module SecureHeaders
         source_list.reject! { |value| value == NONE } if source_list.length > 1
 
         # remove schemes and dedup source expressions
-        source_list = strip_source_schemes(source_list) unless directive_name == REPORT_URI
+        unless directive_name == REPORT_URI || @preserve_schemes
+          source_list = strip_source_schemes(source_list)
+        end
         dedup_source_list(source_list).join(" ")
       end
+
       [symbol_to_hyphen_case(directive_name), value].join(" ")
     end
 

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -138,6 +138,11 @@ module SecureHeaders
         expect(csp.value).to eq("default-src https:; report-uri https://example.org")
       end
 
+      it "does not remove schemes when :preserve_schemes is true" do
+        csp = ContentSecurityPolicy.new(default_src: %w(https://example.org), :preserve_schemes => true)
+        expect(csp.value).to eq("default-src https://example.org")
+      end
+
       it "removes nil from source lists" do
         csp = ContentSecurityPolicy.new(default_src: ["https://example.org", nil])
         expect(csp.value).to eq("default-src example.org")


### PR DESCRIPTION
Before this change, all schemes were stripped from host sources. This is because modern browsers know that on an HTTPS resource, only HTTPS is allowed but on HTTP resources, both HTTP and HTTPS are allowed. Safari on the other hand doesn't support this. In an ideal world, all local development would be over HTTPS and there would never be a need to serve/load HTTP resources.

Adding `:preserve_schemes` (defaults to false) unfortunately also allows mixed content. i.e. If you are on an HTTPS resource, but you've whitelisted an HTTP resource you have allowed mixed content.

The 2.x series does not remove any schemes.