### PR TITLE
:preserve_schemes flag would throw an error if you actually tried to use it ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ SecureHeaders::Configuration.default do |config|
   config.x_permitted_cross_domain_policies = "none"
   config.csp = {
     # "meta" values. these will shaped the header, but the values are not included in the header.
-    report_only:  true,    # default: false
-    preserve_schemes: true # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
+    report_only:  true,     # default: false
+    preserve_schemes: true, # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
 
     # directive values: these values will directly translate into source directives
     default_src: %w(https: 'self'),

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -145,7 +145,12 @@ module SecureHeaders
       STAR,
       DATA_PROTOCOL,
       BLOB_PROTOCOL
-    ]
+    ].freeze
+
+    META_CONFIGS = [
+      :report_only,
+      :preserve_schemes
+    ].freeze
 
     class << self
       # Public: generate a header name, value array that is user-agent-aware.
@@ -165,7 +170,7 @@ module SecureHeaders
         return if config.nil? || config == OPT_OUT
         raise ContentSecurityPolicyConfigError.new(":default_src is required") unless config[:default_src]
         config.each do |key, value|
-          if key == :report_only
+          if META_CONFIGS.include?(key)
             raise ContentSecurityPolicyConfigError.new("#{key} must be a boolean value") unless boolean?(value) || value.nil?
           else
             validate_directive!(key, value)

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -23,6 +23,35 @@ module SecureHeaders
     end
 
     describe "#validate_config!" do
+      it "accepts all keys" do
+        # (pulled from README)
+        config = {
+          # "meta" values. these will shaped the header, but the values are not included in the header.
+          report_only:  true,     # default: false
+          preserve_schemes: true, # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
+
+          # directive values: these values will directly translate into source directives
+          default_src: %w(https: 'self'),
+          frame_src: %w('self' *.twimg.com itunes.apple.com),
+          connect_src: %w(wws:),
+          font_src: %w('self' data:),
+          img_src: %w(mycdn.com data:),
+          media_src: %w(utoob.com),
+          object_src: %w('self'),
+          script_src: %w('self'),
+          style_src: %w('unsafe-inline'),
+          base_uri: %w('self'),
+          child_src: %w('self'),
+          form_action: %w('self' github.com),
+          frame_ancestors: %w('none'),
+          plugin_types: %w(application/x-shockwave-flash),
+          block_all_mixed_content: true, # see [http://www.w3.org/TR/mixed-content/](http://www.w3.org/TR/mixed-content/)
+          report_uri: %w(https://example.com/uri-directive)
+        }
+
+        CSP.validate_config!(config)
+      end
+
       it "requires a :default_src value" do
         expect do
           CSP.validate_config!(script_src: %('self'))
@@ -32,6 +61,12 @@ module SecureHeaders
       it "requires :report_only to be a truthy value" do
         expect do
           CSP.validate_config!(default_opts.merge(report_only: "steve"))
+        end.to raise_error(ContentSecurityPolicyConfigError)
+      end
+
+      it "requires :preserve_schemes to be a truthy value" do
+        expect do
+          CSP.validate_config!(default_opts.merge(preserve_schemes: "steve"))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
 


### PR DESCRIPTION
It tried to treat `:preserve_schemes` as a directive.

As a side benefit, the example config in the README is actually tested for validity now.