### PR TITLE
Directive values may be nil, so secure_headers should not :boom:

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -218,7 +218,7 @@ module SecureHeaders
         # when each hash contains a value for a given key.
         original.merge(additions) do |directive, lhs, rhs|
           if source_list?(directive)
-            (lhs.to_a + rhs.to_a).uniq.compact
+            (lhs.to_a + rhs.to_a).compact.uniq
           else
             rhs
           end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -218,7 +218,7 @@ module SecureHeaders
         # when each hash contains a value for a given key.
         original.merge(additions) do |directive, lhs, rhs|
           if source_list?(directive)
-            (lhs.to_a + rhs).uniq.compact
+            (lhs.to_a + rhs.to_a).uniq.compact
           else
             rhs
           end
@@ -343,6 +343,8 @@ module SecureHeaders
     #
     # Returns a string representing a directive.
     def build_directive(directive_name)
+      return if @config[directive_name].nil?
+
       source_list = @config[directive_name].compact
       return if source_list.empty?
 

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -155,6 +155,7 @@ module SecureHeaders
       specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w())).to be true }
       specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: [nil])).to be true }
       specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, style_src: [nil])).to be true }
+      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, style_src: nil)).to be true }
     end
 
     describe "#value" do
@@ -198,6 +199,11 @@ module SecureHeaders
 
       it "does not add a directive if the value is an empty array (or all nil)" do
         csp = ContentSecurityPolicy.new(default_src: ["https://example.org"], script_src: [nil])
+        expect(csp.value).to eq("default-src example.org")
+      end
+
+      it "does not add a directive if the value is nil" do
+        csp = ContentSecurityPolicy.new(default_src: ["https://example.org"], script_src: nil)
         expect(csp.value).to eq("default-src example.org")
       end
 


### PR DESCRIPTION
Supplying a directive with a value of `nil` could :boom: in two places:

* During `idempotent_additions?` check
* When generating the header