### PR TITLE
Handle policy merges when directives do not inherit from default-src

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -55,6 +55,16 @@ module SecureHeaders
     FRAME_ANCESTORS = :frame_ancestors
     PLUGIN_TYPES = :plugin_types
 
+    # These are directives that do not inherit the default-src value. This is
+    # useful when calling #combine_policies.
+    NON_DEFAULT_SOURCES = [
+      BASE_URI,
+      FORM_ACTION,
+      FRAME_ANCESTORS,
+      PLUGIN_TYPES,
+      REPORT_URI
+    ]
+
     DIRECTIVES_2_0 = [
       DIRECTIVES_1_0,
       BASE_URI,
@@ -214,7 +224,7 @@ module SecureHeaders
 
         # in case we would be appending to an empty directive, fill it with the default-src value
         additions.keys.each do |directive|
-          unless original[directive] || !source_list?(directive)
+          unless original[directive] || !source_list?(directive) || NON_DEFAULT_SOURCES.include?(directive)
             original[directive] = original[:default_src]
           end
         end

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -138,13 +138,15 @@ module SecureHeaders
           }.freeze
         end
         non_default_source_additions = CSP::NON_DEFAULT_SOURCES.each_with_object({}) do |directive, hash|
-          hash[directive] = "http://example.org"
+          hash[directive] = %w("http://example.org)
         end
         combined_config = CSP.combine_policies(Configuration.get.csp, non_default_source_additions)
 
         CSP::NON_DEFAULT_SOURCES.each do |directive|
-          expect(combined_config[directive]).to eq("http://example.org")
+          expect(combined_config[directive]).to eq(%w("http://example.org))
         end
+
+         ContentSecurityPolicy.new(combined_config, USER_AGENTS[:firefox]).value
       end
 
       it "overrides the report_only flag" do

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -124,8 +124,27 @@ module SecureHeaders
             report_only: false
           }.freeze
         end
-        combined_config = CSP.combine_policies(Configuration.get.csp, report_uri: %w(https://report-uri.io/asdf))
-        expect(combined_config[:report_uri]).to_not be_nil
+        report_uri = "https://report-uri.io/asdf"
+        combined_config = CSP.combine_policies(Configuration.get.csp, report_uri: [report_uri])
+        csp = ContentSecurityPolicy.new(combined_config, USER_AGENTS[:firefox])
+        expect(csp.value).to include("report-uri #{report_uri}")
+      end
+
+      it "does not combine the default-src value for directives that don't fall back to default sources" do
+        Configuration.default do |config|
+          config.csp = {
+            default_src: %w('self'),
+            report_only: false
+          }.freeze
+        end
+        non_default_source_additions = CSP::NON_DEFAULT_SOURCES.each_with_object({}) do |directive, hash|
+          hash[directive] = "http://example.org"
+        end
+        combined_config = CSP.combine_policies(Configuration.get.csp, non_default_source_additions)
+
+        CSP::NON_DEFAULT_SOURCES.each do |directive|
+          expect(combined_config[directive]).to eq("http://example.org")
+        end
       end
 
       it "overrides the report_only flag" do


### PR DESCRIPTION
Previously, non default source values would be merged with the default-src value which makes no sense. This was especially confusing if your default-src was `*` or `'none'`

I'm going to wait until I confirm that `plugin-types` is a non-default source directive. The spec does not mention it explicitly, and I've submitted https://github.com/w3c/webappsec/pull/510 in case my hunch is correct.