### PR TITLE
Handle very dynamic policies better

### DIFF
--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -75,8 +75,7 @@ module SecureHeaders
     # Returns the current config
     def override_x_frame_options(request, value)
       config = config_for(request)
-      config.x_frame_options = value
-      config.cached_headers[XFrameOptions::CONFIG_KEY] = make_header(XFrameOptions, config.x_frame_options)
+      config.update_x_frame_options(value)
       override_secure_headers_request_config(request, config)
     end
 

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -53,7 +53,7 @@ module SecureHeaders
       end
 
       csp = Configuration.deep_copy(config.current_csp)
-      config.dynamic_csp = csp.merge!(additions)
+      config.dynamic_csp = csp.merge(additions)
       override_secure_headers_request_config(request, config)
     end
 

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -52,8 +52,7 @@ module SecureHeaders
         config.csp = config.dynamic_csp = {}
       end
 
-      csp = Configuration.deep_copy(config.current_csp)
-      config.dynamic_csp = csp.merge(additions)
+      config.dynamic_csp = config.current_csp.merge(additions)
       override_secure_headers_request_config(request, config)
     end
 
@@ -65,8 +64,7 @@ module SecureHeaders
     #    script_src: %w(another-host.com)
     def append_content_security_policy_directives(request, additions)
       config = config_for(request)
-      csp = Configuration.deep_copy(config.current_csp)
-      config.dynamic_csp = CSP.combine_policies(csp, additions)
+      config.dynamic_csp = CSP.combine_policies(config.current_csp, additions)
       override_secure_headers_request_config(request, config)
     end
 

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -83,10 +83,7 @@ module SecureHeaders
     # and setting the given headers config to OPT_OUT.
     def opt_out_of_header(request, header_key)
       config = config_for(request)
-      config.send("#{header_key}=", OPT_OUT)
-      if header_key == CSP::CONFIG_KEY
-        config.dynamic_csp = OPT_OUT
-      end
+      config.opt_out(header_key)
       override_secure_headers_request_config(request, config)
     end
 

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -49,7 +49,7 @@ module SecureHeaders
     def override_content_security_policy_directives(request, additions)
       config = config_for(request)
       if config.current_csp == OPT_OUT
-        config.csp = config.dynamic_csp = {}
+        config.dynamic_csp = {}
       end
 
       config.dynamic_csp = config.current_csp.merge(additions)

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -115,7 +115,7 @@ module SecureHeaders
       copy.csp = deep_copy_hash(csp)
       copy.dynamic_csp = deep_copy_hash(dynamic_csp)
       copy.hpkp = deep_copy_hash(hpkp)
-      copy.send(:cached_headers=, deep_copy_hash(cached_headers))
+      copy.cached_headers = deep_copy_hash(cached_headers)
       copy
     end
 
@@ -163,11 +163,13 @@ module SecureHeaders
       PublicKeyPins.validate_config!(hpkp)
     end
 
-    private
+    protected
 
     def cached_headers=(headers)
       @cached_headers = headers
     end
+
+    private
 
     # Public: Precompute the header names and values for this configuraiton.
     # Ensures that headers generated at configure time, not on demand.

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -129,6 +129,14 @@ module SecureHeaders
       copy
     end
 
+    def opt_out(header)
+      send("#{header}=", OPT_OUT)
+      if header == CSP::CONFIG_KEY
+        dynamic_csp = OPT_OUT
+      end
+      self.cached_headers.delete(header)
+    end
+
     def update_x_frame_options(value)
       self.x_frame_options = value
       self.cached_headers[XFrameOptions::CONFIG_KEY] = XFrameOptions.make_header(self.x_frame_options)

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -103,6 +103,7 @@ module SecureHeaders
     # Returns a deep-dup'd copy of this configuration.
     def dup
       copy = self.class.new
+      copy.secure_cookies = secure_cookies
       copy.hsts = hsts
       copy.x_frame_options = x_frame_options
       copy.x_content_type_options = x_content_type_options

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -218,7 +218,7 @@ module SecureHeaders
           raise ContentSecurityPolicyConfigError.new("Attempted to override an opt-out CSP config.")
         end
 
-        original = original.dup
+        original = Configuration.send(:deep_copy, original)
         populate_fetch_source_with_default!(original, additions)
         merge_policy_additions(original, additions)
       end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -197,7 +197,7 @@ module SecureHeaders
       # because google.com is already in the config.
       def idempotent_additions?(config, additions)
         return false if config == OPT_OUT
-        config.to_s == combine_policies(config, additions).to_s
+        config == combine_policies(config, additions)
       end
 
       # Public: combine the values from two different configs.
@@ -218,7 +218,7 @@ module SecureHeaders
           raise ContentSecurityPolicyConfigError.new("Attempted to override an opt-out CSP config.")
         end
 
-        original = original.dup if original.frozen?
+        original = original.dup
         populate_fetch_source_with_default!(original, additions)
         merge_policy_additions(original, additions)
       end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -223,6 +223,14 @@ module SecureHeaders
         merge_policy_additions(original, additions)
       end
 
+      def ua_to_variation(user_agent)
+        if family = user_agent.browser && VARIATIONS.key?(family)
+          VARIATIONS[family]
+        else
+          OTHER
+        end
+      end
+
       private
 
       # merge the two hashes. combine (instead of overwrite) the array values

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -29,16 +29,14 @@ module SecureHeaders
       expect_default_values(header_hash)
     end
 
-    it "copies all config values except for the cached headers when dup" do
+    it "copies config values when duping" do
       Configuration.override(:test_override, Configuration::NOOP_CONFIGURATION) do
         # do nothing, just copy it
       end
 
       config = Configuration.get(:test_override)
       noop = Configuration.get(Configuration::NOOP_CONFIGURATION)
-      [:hsts, :x_frame_options, :x_content_type_options, :x_xss_protection,
-        :x_download_options, :x_permitted_cross_domain_policies, :hpkp, :csp, :secure_cookies].each do |key|
-
+      [:csp, :dynamic_csp].each do |key|
         expect(config.send(key)).to eq(noop.send(key)), "Value not copied: #{key}."
       end
     end

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -36,7 +36,7 @@ module SecureHeaders
 
       config = Configuration.get(:test_override)
       noop = Configuration.get(Configuration::NOOP_CONFIGURATION)
-      [:csp, :dynamic_csp].each do |key|
+      [:csp, :dynamic_csp, :secure_cookies].each do |key|
         expect(config.send(key)).to eq(noop.send(key)), "Value not copied: #{key}."
       end
     end

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -33,6 +33,7 @@ module SecureHeaders
       end
       request = Rack::Request.new({})
       SecureHeaders.use_secure_headers_override(request, "my_custom_config")
+      expect(request.env[SECURE_HEADERS_CONFIG]).to be(Configuration.get("my_custom_config"))
       _, env = middleware.call request.env
       expect(env[CSP::HEADER_NAME]).to match("example.org")
     end

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -115,7 +115,7 @@ module SecureHeaders
 
           SecureHeaders.append_content_security_policy_directives(request, script_src: %w(anothercdn.com))
           new_config = SecureHeaders.config_for(request)
-          expect(new_config).to_not be(SecureHeaders::Configuration.get)
+          expect(new_config).to_not be(Configuration.get)
 
           SecureHeaders.override_content_security_policy_directives(request, script_src: %w(yet.anothercdn.com))
           current_config = SecureHeaders.config_for(request)

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -113,6 +113,9 @@ module SecureHeaders
             }
           end
 
+          # before an override occurs, the env is empty
+          expect(request.env[SECURE_HEADERS_CONFIG]).to be_nil
+
           SecureHeaders.append_content_security_policy_directives(request, script_src: %w(anothercdn.com))
           new_config = SecureHeaders.config_for(request)
           expect(new_config).to_not be(Configuration.get)

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -109,6 +109,22 @@ module SecureHeaders
           expect(hash[CSP::HEADER_NAME]).to eq("default-src 'self'; script-src mycdn.com 'unsafe-inline' anothercdn.com")
         end
 
+        it "dups global configuration just once when overriding n times" do
+          Configuration.default do |config|
+            config.csp = {
+              default_src: %w('self')
+            }
+          end
+
+          SecureHeaders.append_content_security_policy_directives(@request, script_src: %w(anothercdn.com))
+          new_config = SecureHeaders.config_for(@request)
+          expect(new_config).to_not be(SecureHeaders::Configuration.get)
+
+          SecureHeaders.override_content_security_policy_directives(@request, script_src: %w(yet.anothercdn.com))
+          current_config = SecureHeaders.config_for(@request)
+          expect(current_config).to be(new_config)
+        end
+
         it "overrides individual directives" do
           Configuration.default do |config|
             config.csp = {

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -35,9 +35,11 @@ module SecureHeaders
       it "allows you to opt out of individual headers" do
         Configuration.default
         SecureHeaders.opt_out_of_header(@request, CSP::CONFIG_KEY)
+        SecureHeaders.opt_out_of_header(@request, XContentTypeOptions::CONFIG_KEY)
         hash = SecureHeaders.header_hash_for(@request)
         expect(hash['Content-Security-Policy-Report-Only']).to be_nil
         expect(hash['Content-Security-Policy']).to be_nil
+        expect(hash['X-Content-Type-Options']).to be_nil
       end
 
       it "allows you to opt out entirely" do

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -2,18 +2,6 @@ require 'spec_helper'
 
 module SecureHeaders
   describe SecureHeaders do
-    example_hpkp_config = {
-      max_age: 1_000_000,
-      include_subdomains: true,
-      report_uri: '//example.com/uri-directive',
-      pins: [
-        { sha256: 'abc' },
-        { sha256: '123' }
-      ]
-    }
-
-    example_hpkp_config_value = %(max-age=1000000; pin-sha256="abc"; pin-sha256="123"; report-uri="//example.com/uri-directive"; includeSubDomains)
-
     before(:each) do
       reset_config
     end
@@ -90,7 +78,15 @@ module SecureHeaders
       it "does not set the HPKP header if request is over HTTP" do
         plaintext_request = Rack::Request.new({})
         Configuration.default do |config|
-          config.hpkp = example_hpkp_config
+          config.hpkp = {
+            max_age: 1_000_000,
+            include_subdomains: true,
+            report_uri: '//example.com/uri-directive',
+            pins: [
+              { sha256: 'abc' },
+              { sha256: '123' }
+            ]
+          }
         end
 
         expect(SecureHeaders.header_hash_for(plaintext_request)[PublicKeyPins::HEADER_NAME]).to be_nil

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -16,7 +16,6 @@ module SecureHeaders
 
     before(:each) do
       reset_config
-
     end
 
     let(:request) { Rack::Request.new("HTTP_X_FORWARDED_SSL" => "on") }


### PR DESCRIPTION
Fixes #217 

Currently, an idempotency check is performed for every policy addition. Not only does this create a fair number of temporary objects, but it also busts the entire header cache if any changes are detected.

This change defers idempotency checks until just before the header values are generated. If we can determine that the CSP will differ from the cached values, we discard all cached CSP and generate one specific to that UA.

If there is a change to `X-Frame-Options`, we cache the new value immediately.

As a result, the value for `cached_headers` will always maintain the headers that will be applied and there is no need to generate them when calling `header_hash_for`. 

Because we are retaining the previously discarded cached headers, we only call `dup` on the configuration option if it is `frozen` to save bytes and cycles. All policies added via `default` and `override` are already frozen automatically, so a non-`frozen` config object can be modified freely and we can assume it's dynamic in nature.

To recap:

| Before | After |
| --- | --- |
| `idempotent_additions?` called per policy modification | `idempotent_additions?` called once per request |
| Entire header cache was busted per policy/xfo modification | the CSP header cache is busted once per request, only policies for the current UA are regenerated |
| config objects were `dup`'d per modification | config values `dup`'d at most one time per request |
| XFO changes busted the entire header cache | XFO changes modify the header cache directly |
| Opting out of a header would bust the cache | Opting out of a header modifies the cache |