### PR TITLE
Opting out of all protection would raise an exception because the idempotency check was wrong

### DIFF
--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -71,6 +71,7 @@ module SecureHeaders
           ALL_HEADER_CLASSES.each do |klass|
             config.send("#{klass::CONFIG_KEY}=", OPT_OUT)
           end
+          config.dynamic_csp = OPT_OUT
         end
 
         add_configuration(NOOP_CONFIGURATION, noop_config)

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -196,6 +196,7 @@ module SecureHeaders
       # additions = { script_src: %w(google.com)} then idempotent_additions? would return
       # because google.com is already in the config.
       def idempotent_additions?(config, additions)
+        return true if config == OPT_OUT && additions == OPT_OUT
         return false if config == OPT_OUT
         config == combine_policies(config, additions)
       end

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -38,6 +38,7 @@ module SecureHeaders
         ALL_HEADER_CLASSES.each do |klass|
           expect(hash[klass::CONFIG_KEY]).to be_nil
         end
+        expect(hash.count).to eq(0)
       end
 
       it "allows you to override X-Frame-Options settings" do


### PR DESCRIPTION
`idempotent_additions?` would return false when comparing `OPT_OUT` with `OPT_OUT`, causing `header_hash_for` to return a header cache with `{ nil => nil }` which cause the middleware to blow up when `{ nil => nil }` was merged into the rack header hash. 

This is a regression in 3.1.0 only.

Now it returns true. I've added a test case to ensure that `header_hash_for` will never return such an element.