### PR TITLE
Regression: overrides were not carrying configuration values forward

### DIFF
--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -121,6 +121,13 @@ module SecureHeaders
       copy.csp = self.class.send(:deep_copy_if_hash, @csp)
       copy.dynamic_csp = self.class.send(:deep_copy_if_hash, @dynamic_csp)
       copy.cached_headers = self.class.send(:deep_copy_if_hash, @cached_headers)
+      copy.x_content_type_options = @x_content_type_options
+      copy.hsts = @hsts
+      copy.x_frame_options = @x_frame_options
+      copy.x_xss_protection = @x_xss_protection
+      copy.x_download_options = @x_download_options
+      copy.x_permitted_cross_domain_policies = @x_permitted_cross_domain_policies
+      copy.hpkp = @hpkp
       copy
     end
 
@@ -133,6 +140,7 @@ module SecureHeaders
     end
 
     def update_x_frame_options(value)
+      @x_frame_options = value
       self.cached_headers[XFrameOptions::CONFIG_KEY] = XFrameOptions.make_header(value)
     end
 

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -41,6 +41,14 @@ module SecureHeaders
       end
     end
 
+    it "regenerates cached headers when building an override" do
+      Configuration.override(:test_override) do |config|
+        config.x_content_type_options = OPT_OUT
+      end
+
+      expect(Configuration.get.cached_headers).to_not eq(Configuration.get(:test_override).cached_headers)
+    end
+
     it "stores an override of the global config" do
       Configuration.override(:test_override) do |config|
         config.x_frame_options = "DENY"


### PR DESCRIPTION
This meant that when header caches were regenerated upon calling `SecureHeaders.override(:name)` and using it with `use_secure_headers_override` would result in default values for anything other than CSP/HPKP. 