### PR TITLE
Account for `ActionDispatch::SSL` in middleware ordering

### DIFF
--- a/lib/secure_headers/railtie.rb
+++ b/lib/secure_headers/railtie.rb
@@ -10,7 +10,11 @@ if defined?(Rails::Railtie)
                              'Public-Key-Pins', 'Public-Key-Pins-Report-Only']
 
       initializer "secure_headers.middleware" do
-        Rails.application.config.middleware.use SecureHeaders::Middleware
+        if defined?(ActionDispatch::SSL)
+          Rails.application.config.middleware.insert_after ActionDispatch::SSL, SecureHeaders::Middleware
+        else
+          Rails.application.config.middleware.insert_before 0, SecureHeaders::Middleware
+        end
       end
 
       initializer "secure_headers.action_controller" do


### PR DESCRIPTION
Rails 4.0 stable [introduced](https://github.com/rails/rails/commit/9ec63eb0491a1b72381833478398c369ab48019a#diff-8e5f6b33c191ad6dec07f3288345a13f) `ActionDispatch::SSL` to replace the previous
dependency on `Rack::SSL` for setting HSTS HTTP headers. In doing so they have
caused an issue with the middleware load order where the values from
`SecureHeaders::Middleware` are overridden by `ActionDispatch::SSL` due to it
being loaded afterwards.

This fixes the load issue by checking if `ActionDispatch::SSL` is used and
inserting the secure headers middleware after it instead of Rails determining
the load order. The approach used here should also allow those running older
Rails applications to maintain compatibility without any changes.

Fixes #237.