### PR TITLE
Warn if HPKP report host is the same as the current host

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,9 +330,7 @@ config.hpkp = {
     {sha256: '73a2c64f9545172c1195efb6616ca5f7afd1df6f245407cafb90de3998a1c97f'}
   ],
   report_only: true,            # defaults to false (report-only mode)
-  report_uri: 'https://report-uri.io/example-hpkp',
-  app_name: 'example',
-  tag_report_uri: true
+  report_uri: 'https://report-uri.io/example-hpkp'
 }
 ```
 

--- a/lib/secure_headers/middleware.rb
+++ b/lib/secure_headers/middleware.rb
@@ -1,5 +1,7 @@
 module SecureHeaders
   class Middleware
+    HPKP_SAME_HOST_WARNING = "[WARNING] HPKP report host should not be the same as the request host. See https://github.com/twitter/secureheaders/issues/166"
+
     def initialize(app)
       @app = app
     end
@@ -10,6 +12,10 @@ module SecureHeaders
       status, headers, response = @app.call(env)
 
       config = SecureHeaders.config_for(req)
+      if config.hpkp_report_host == req.host
+        Kernel.warn(HPKP_SAME_HOST_WARNING)
+      end
+
       flag_cookies!(headers, override_secure(env, config.cookies)) if config.cookies
       headers.merge!(SecureHeaders.header_hash_for(req))
       [status, headers, response]

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -13,6 +13,23 @@ module SecureHeaders
       Configuration.default
     end
 
+    it "warns if the hpkp report-uri host is the same as the current host" do
+      Configuration.default do |config|
+        config.hpkp = {
+          max_age: 10000000,
+          pins: [
+            {sha256: 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c'},
+            {sha256: '73a2c64f9545172c1195efb6616ca5f7afd1df6f245407cafb90de3998a1c97f'}
+          ],
+          report_uri: 'https://report-uri.io/example-hpkp'
+        }
+      end
+
+      expect(Kernel).to receive(:warn).with(Middleware::HPKP_SAME_HOST_WARNING)
+
+      middleware.call(Rack::MockRequest.env_for("https://report-uri.io", {}))
+    end
+
     it "sets the headers" do
       _, env = middleware.call(Rack::MockRequest.env_for("https://looocalhost", {}))
       expect_default_values(env)

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -14,6 +14,7 @@ module SecureHeaders
     end
 
     it "warns if the hpkp report-uri host is the same as the current host" do
+      report_host = "report-uri.io"
       Configuration.default do |config|
         config.hpkp = {
           max_age: 10000000,
@@ -21,13 +22,13 @@ module SecureHeaders
             {sha256: 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c'},
             {sha256: '73a2c64f9545172c1195efb6616ca5f7afd1df6f245407cafb90de3998a1c97f'}
           ],
-          report_uri: 'https://report-uri.io/example-hpkp'
+          report_uri: "https://#{report_host}/example-hpkp"
         }
       end
 
       expect(Kernel).to receive(:warn).with(Middleware::HPKP_SAME_HOST_WARNING)
 
-      middleware.call(Rack::MockRequest.env_for("https://report-uri.io", {}))
+      middleware.call(Rack::MockRequest.env_for("https://#{report_host}", {}))
     end
 
     it "sets the headers" do


### PR DESCRIPTION
Fixes https://github.com/twitter/secureheaders/issues/166