### PR TITLE
Fix false booleans being included in the CSP directive

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -53,7 +53,7 @@ module SecureHeaders
       directives.map do |directive_name|
         case DIRECTIVE_VALUE_TYPES[directive_name]
         when :boolean
-          symbol_to_hyphen_case(directive_name)
+          symbol_to_hyphen_case(directive_name) if @config[directive_name]
         when :string
           [symbol_to_hyphen_case(directive_name), @config[directive_name]].join(" ")
         else

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -71,6 +71,16 @@ module SecureHeaders
         expect(csp.value).to eq("default-src example.org")
       end
 
+      it "does add a boolean directive if the value is true" do
+        csp = ContentSecurityPolicy.new(default_src: ["https://example.org"], block_all_mixed_content: true, upgrade_insecure_requests: true)
+        expect(csp.value).to eq("default-src example.org; block-all-mixed-content; upgrade-insecure-requests")
+      end
+
+      it "does not add a boolean directive if the value is false" do
+        csp = ContentSecurityPolicy.new(default_src: ["https://example.org"], block_all_mixed_content: true, upgrade_insecure_requests: false)
+        expect(csp.value).to eq("default-src example.org; block-all-mixed-content")
+      end
+
       it "deduplicates any source expressions" do
         csp = ContentSecurityPolicy.new(default_src: %w(example.org example.org example.org))
         expect(csp.value).to eq("default-src example.org")


### PR DESCRIPTION
I was using `upgrade_insecure_requests: false` but I still got `upgrade-insecure-requests` in my header. It would appear this is a bug?