### PR TITLE
allows child-src values for firefox headers

### DIFF
--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -96,7 +96,6 @@ module SecureHeaders
 
     FIREFOX_UNSUPPORTED_DIRECTIVES = [
       BLOCK_ALL_MIXED_CONTENT,
-      CHILD_SRC,
       PLUGIN_TYPES
     ].freeze
 


### PR DESCRIPTION
Partial fix for https://github.com/twitter/secureheaders/issues/260

It will not eliminate the deprecation warning, but it will at least allow the value. 