### PR TITLE
hook include of helper to loading of ActionView

### DIFF
--- a/lib/secure_headers/view_helper.rb
+++ b/lib/secure_headers/view_helper.rb
@@ -108,8 +108,6 @@ module SecureHeaders
   end
 end
 
-module ActionView #:nodoc:
-  class Base #:nodoc:
-    include SecureHeaders::ViewHelpers
-  end
+ActiveSupport.on_load :action_view do
+  include SecureHeaders::ViewHelpers
 end

--- a/lib/secure_headers/view_helper.rb
+++ b/lib/secure_headers/view_helper.rb
@@ -110,4 +110,4 @@ end
 
 ActiveSupport.on_load :action_view do
   include SecureHeaders::ViewHelpers
-end
+end if defined?(ActiveSupport)


### PR DESCRIPTION
## All PRs:

* [ ] Has tests
* [ ] Documentation updated

When using rspec with rails-controller-testing, specs would break due to incorrect load order. More info here: https://github.com/rails/rails-controller-testing/issues/24