### PR TITLE
Setting two CSP headers, abstract out dynamic pieces

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,32 @@ use SecureHeaders::Middleware
 
 ## Default values
 
-All headers except for PublicKeyPins have a default value. See the [corresponding classes for their defaults](https://github.com/twitter/secureheaders/tree/master/lib/secure_headers/headers).
+All headers except for PublicKeyPins have a default value. See the [corresponding classes for their defaults](https://github.com/twitter/secureheaders/tree/master/lib/secure_headers/headers). The default set of headers is:
+
+```
+Content-Security-Policy: default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline'
+Strict-Transport-Security: max-age=631138519
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: sameorigin
+X-Permitted-Cross-Domain-Policies: none
+X-Xss-Protection: 1; mode=block
+```
+
+### Default CSP
+
+By default, the above CSP will be applied to all requests. If you **only** want to set a Report-Only header, opt-out of the default enforced header for clarity. The configuration will assume that if you only supply `csp_report_only` that you intended to opt-out of `csp` but that's for the sake of backwards compatibility and it will be removed in the future.
+
+```ruby
+Configuration.default do |config|
+  config.csp = SecureHeaders::OPT_OUT # If this line is omitted, we will assume you meant to opt out.
+  config.csp_report_only = {
+    default_src: %w('self')
+  }
+end
+```
+
+If **
 
 ## Named overrides
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ SecureHeaders::Configuration.default do |config|
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"
     samesite: {
-      strict: true # mark all cookies as SameSite=Strict
+      lax: true # mark all cookies as SameSite=lax
     }
   }
   config.hsts = "max-age=#{20.years.to_i}; includeSubdomains; preload"
@@ -48,7 +48,7 @@ SecureHeaders::Configuration.default do |config|
   config.referrer_policy = "origin-when-cross-origin"
   config.csp = {
     # "meta" values. these will shaped the header, but the values are not included in the header.
-    report_only: true,      # default: false
+    report_only: true,      # default: false [DEPRECATED: instead, configure csp_report_only]
     preserve_schemes: true, # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
 
     # directive values: these values will directly translate into source directives
@@ -69,6 +69,10 @@ SecureHeaders::Configuration.default do |config|
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
     report_uri: %w(https://report-uri.io/example-csp)
   }
+  config.csp_report_only = config.csp.merge({
+    img_src: %w(somewhereelse.com),
+    report_uri: %w(https://report-uri.io/example-csp-report-only)
+  })
   config.hpkp = {
     report_only: false,
     max_age: 60.days.to_i,

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -106,11 +106,11 @@ module SecureHeaders
     def append_content_security_policy_directives(request, additions, target = nil)
       config, target = config_and_target(request, target)
 
-      if [:both, :enforced].include?(target) && config.csp != OPT_OUT
+      if [:both, :enforced].include?(target) && !config.csp.opt_out?
         config.csp.append(additions)
       end
 
-      if [:both, :report_only].include?(target) && config.csp_report_only != OPT_OUT
+      if [:both, :report_only].include?(target) && !config.csp_report_only.opt_out?
         config.csp_report_only.append(additions)
       end
 

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -34,6 +34,10 @@ module SecureHeaders
       self.class.instance
     end
 
+    def opt_out?
+      true
+    end
+
     alias_method :[], :boom
     alias_method :[]=, :boom
     alias_method :keys, :boom
@@ -75,7 +79,7 @@ module SecureHeaders
       config, target = config_and_target(request, target)
 
       if [:both, :enforced].include?(target)
-        if config.csp == OPT_OUT
+        if config.csp.opt_out?
           config.csp = ContentSecurityPolicyConfig.new({})
         end
 
@@ -83,7 +87,7 @@ module SecureHeaders
       end
 
       if [:both, :report_only].include?(target)
-        if config.csp_report_only == OPT_OUT
+        if config.csp_report_only.opt_out?
           config.csp_report_only = ContentSecurityPolicyReportOnlyConfig.new({})
         end
 

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -155,11 +155,11 @@ module SecureHeaders
       config = config_for(request, prevent_dup = true)
       headers = config.cached_headers
 
-      if config.csp != OPT_OUT && config.csp.modified?
+      if !config.csp.opt_out? && config.csp.modified?
         headers = update_cached_csp(config, headers, request.user_agent, CSP::CONFIG_KEY)
       end
 
-      if config.csp_report_only != OPT_OUT && config.csp_report_only.modified?
+      if !config.csp_report_only.opt_out? && config.csp_report_only.modified?
         headers = update_cached_csp(config, headers, request.user_agent, CSP::REPORT_ONLY_CONFIG_KEY)
       end
 
@@ -234,9 +234,9 @@ module SecureHeaders
     def guess_target(config)
       if !config.csp.opt_out? && !config.csp_report_only.opt_out?
         :both
-      elsif config.csp != OPT_OUT
+      elsif !config.csp.opt_out?
         :enforced
-      elsif config.csp_report_only != OPT_OUT
+      elsif !config.csp_report_only.opt_out?
         :report_only
       else
         :both
@@ -310,24 +310,6 @@ module SecureHeaders
     # Returns a CSP [header, value] array
     def csp_header_for_ua(headers, request)
       headers[CSP.ua_to_variation(UserAgent.parse(request.user_agent))]
-    end
-
-    # Private: optionally build a header with a given configure
-    #
-    # klass - corresponding Class for a given header
-    # config - A string, symbol, or hash config for the header
-    # user_agent - A string representing the UA  (only used for CSP feature sniffing)
-    #
-    # Returns a 2 element array [header_name, header_value] or nil if config
-    # is OPT_OUT
-    def make_header(klass, header_config, user_agent = nil)
-      unless header_config == OPT_OUT
-        if klass == CSP
-          klass.make_header(header_config, user_agent)
-        else
-          klass.make_header(header_config)
-        end
-      end
     end
   end
 

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -127,16 +127,19 @@ module SecureHeaders
     # in Rack middleware.
     def header_hash_for(request)
       config = config_for(request)
-      puts "final config#{ config.inspect}"
+      puts "\nfinal config\n#{ config.inspect}"
       unless ContentSecurityPolicy.idempotent_additions?(config.csp, config.current_csp)
         config.rebuild_csp_header_cache!(request.user_agent, CSP::CONFIG_KEY)
       end
+
+      puts "\nafter enforced changes\n#{ config.inspect}"
 
       unless ContentSecurityPolicy.idempotent_additions?(config.csp_report_only, config.current_csp_report_only)
         config.rebuild_csp_header_cache!(request.user_agent, CSP::REPORT_ONLY_CONFIG_KEY)
       end
 
-      puts "final config with cache#{ config.inspect}"
+      puts "\nfinal config with cache\n#{ config.inspect}"
+      pp config.cached_headers
 
       use_cached_headers(config.cached_headers, request)
     end

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -18,7 +18,10 @@ require "useragent"
 # All headers (except for hpkp) have a default value. Provide SecureHeaders::OPT_OUT
 # or ":optout_of_protection" as a config value to disable a given header
 module SecureHeaders
-  OPT_OUT = :opt_out_of_protection
+  class NoOpHeaderConfig
+  end
+
+  OPT_OUT = NoOpHeaderConfig.new
   SECURE_HEADERS_CONFIG = "secure_headers_request_config".freeze
   NONCE_KEY = "secure_headers_content_security_policy_nonce".freeze
   HTTPS = "https".freeze

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -14,13 +14,24 @@ require "secure_headers/middleware"
 require "secure_headers/railtie"
 require "secure_headers/view_helper"
 require "useragent"
+require "singleton"
 
 # All headers (except for hpkp) have a default value. Provide SecureHeaders::OPT_OUT
 # or ":optout_of_protection" as a config value to disable a given header
 module SecureHeaders
   class NoOpHeaderConfig
-    def boom
+    include Singleton
+
+    def boom(arg = nil)
       raise "Illegal State: attempted to modify NoOpHeaderConfig. Create a new config instead."
+    end
+
+    def to_h
+      {}
+    end
+
+    def dup
+      self.class.instance
     end
 
     alias_method :[], :boom
@@ -28,7 +39,7 @@ module SecureHeaders
     alias_method :keys, :boom
   end
 
-  OPT_OUT = NoOpHeaderConfig.new
+  OPT_OUT = NoOpHeaderConfig.instance
   SECURE_HEADERS_CONFIG = "secure_headers_request_config".freeze
   NONCE_KEY = "secure_headers_content_security_policy_nonce".freeze
   HTTPS = "https".freeze

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -148,19 +148,13 @@ module SecureHeaders
     # in Rack middleware.
     def header_hash_for(request)
       config = config_for(request)
-      puts "\nfinal config\n#{ config.inspect}"
       if config.csp != OPT_OUT && config.csp.modified?
         config.rebuild_csp_header_cache!(request.user_agent, CSP::CONFIG_KEY)
       end
 
-      puts "\nafter enforced changes\n#{ config.inspect}"
-
       if config.csp_report_only != OPT_OUT && config.csp_report_only.modified?
         config.rebuild_csp_header_cache!(request.user_agent, CSP::REPORT_ONLY_CONFIG_KEY)
       end
-
-      puts "\nfinal config with cache\n#{ config.inspect}"
-      pp config.cached_headers
 
       use_cached_headers(config.cached_headers, request)
     end

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -19,6 +19,13 @@ require "useragent"
 # or ":optout_of_protection" as a config value to disable a given header
 module SecureHeaders
   class NoOpHeaderConfig
+    def boom
+      raise "Illegal State: attempted to modify NoOpHeaderConfig. Create a new config instead."
+    end
+
+    alias_method :[], :boom
+    alias_method :[]=, :boom
+    alias_method :keys, :boom
   end
 
   OPT_OUT = NoOpHeaderConfig.new

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -228,7 +228,9 @@ module SecureHeaders
     end
 
     def guess_target(config)
-      if config.csp != OPT_OUT
+      if config.csp != OPT_OUT && config.csp_report_only != OPT_OUT
+        :both
+      elsif config.csp != OPT_OUT
         :enforced
       elsif config.csp_report_only != OPT_OUT
         :report_only

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -232,7 +232,7 @@ module SecureHeaders
     end
 
     def guess_target(config)
-      if config.csp != OPT_OUT && config.csp_report_only != OPT_OUT
+      if !config.csp.opt_out? && !config.csp_report_only.opt_out?
         :both
       elsif config.csp != OPT_OUT
         :enforced

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -261,8 +261,8 @@ module SecureHeaders
     #
     # Returns nothing
     def generate_csp_headers(headers)
-      generate_csp_headers_for_config(headers, CSP::CONFIG_KEY, self.csp)
-      generate_csp_headers_for_config(headers, CSPRO::CONFIG_KEY, self.csp_report_only)
+      generate_csp_headers_for_config(headers, ContentSecurityPolicyConfig::CONFIG_KEY, self.csp)
+      generate_csp_headers_for_config(headers, ContentSecurityPolicyReportOnlyConfig::CONFIG_KEY, self.csp_report_only)
     end
 
     def generate_csp_headers_for_config(headers, header_key, csp_config)

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -84,6 +84,7 @@ module SecureHeaders
       # Public: perform a basic deep dup. The shallow copy provided by dup/clone
       # can lead to modifying parent objects.
       def deep_copy(config)
+        return unless config
         config.each_with_object({}) do |(key, value), hash|
           hash[key] = if value.is_a?(Array)
             value.dup
@@ -217,7 +218,6 @@ module SecureHeaders
           Kernel.warn "#{Kernel.caller.first}: [DEPRECATION] `#csp=` was supplied a config with report_only: true. Use #csp_report_only="
         end
       end
-
       if self.dynamic_csp
         raise IllegalPolicyModificationError, "You are attempting to modify CSP settings directly. Use dynamic_csp= instead."
       end

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -184,7 +184,9 @@ module SecureHeaders
         @csp = new_csp.dup
       else
         if new_csp[:report_only]
+          # Deprecated configuration implies that CSPRO should be set, CSP should not - so opt out
           Kernel.warn "#{Kernel.caller.first}: [DEPRECATION] `#csp=` was supplied a config with report_only: true. Use #csp_report_only="
+          @csp = OPT_OUT
           self.csp_report_only = new_csp
         else
           @csp = ContentSecurityPolicyConfig.new(new_csp)

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -272,7 +272,7 @@ module SecureHeaders
     end
 
     def generate_csp_headers_for_config(headers, header_key, csp_config)
-      unless csp_config == OPT_OUT
+      unless csp_config.opt_out?
         headers[header_key] = {}
         CSP::VARIATIONS.each do |name, _|
           csp = CSP.make_header(csp_config, UserAgent.parse(name))

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -262,14 +262,14 @@ module SecureHeaders
     # Returns nothing
     def generate_csp_headers(headers)
       generate_csp_headers_for_config(headers, CSP::CONFIG_KEY, self.csp)
-      generate_csp_headers_for_config(headers, CSP::REPORT_ONLY_CONFIG_KEY, self.csp_report_only)
+      generate_csp_headers_for_config(headers, CSPRO::CONFIG_KEY, self.csp_report_only)
     end
 
     def generate_csp_headers_for_config(headers, header_key, csp_config)
       unless csp_config.opt_out?
         headers[header_key] = {}
-        CSP::VARIATIONS.each do |name, _|
-          csp = CSP.make_header(csp_config, UserAgent.parse(name))
+        ContentSecurityPolicy::VARIATIONS.each do |name, _|
+          csp = ContentSecurityPolicy.make_header(csp_config, UserAgent.parse(name))
           headers[header_key][name] = csp.freeze
         end
       end

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -191,14 +191,12 @@ module SecureHeaders
       @cookies = (@cookies || {}).merge(secure: secure_cookies)
     end
 
-    protected
-
     def csp=(new_csp)
       if new_csp == OPT_OUT
         @csp = OPT_OUT
       else
         if new_csp.is_a?(ContentSecurityPolicyConfig)
-          @csp = new_csp
+          @csp = new_csp.dup
         else
           if new_csp[:report_only]
             Kernel.warn "#{Kernel.caller.first}: [DEPRECATION] `#csp=` was supplied a config with report_only: true. Use #csp_report_only="
@@ -214,16 +212,20 @@ module SecureHeaders
       if new_csp == OPT_OUT
         @csp_report_only = OPT_OUT
       else
-        if new_csp.is_a?(Hash)
-          new_csp = ContentSecurityPolicyReportOnlyConfig.new(new_csp)
+        new_csp = if new_csp.is_a?(ContentSecurityPolicyConfig)
+          ContentSecurityPolicyReportOnlyConfig.new(new_csp.to_h)
+        elsif new_csp.is_a?(Hash)
           if new_csp[:report_only] == false
             Kernel.warn "#{Kernel.caller.first}: [DEPRECATION] `#csp_report_only=` was supplied a config with report_only: false. Use #csp="
           end
+          ContentSecurityPolicyReportOnlyConfig.new(new_csp)
         end
 
         @csp_report_only = new_csp
       end
     end
+
+    protected
 
     def cookies=(cookies)
       @cookies = cookies

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -119,7 +119,7 @@ module SecureHeaders
     def initialize(&block)
       self.hpkp = OPT_OUT
       self.referrer_policy = OPT_OUT
-      self.csp = ContentSecurityPolicyConfig::DEFAULT
+      self.csp = ContentSecurityPolicyConfig.new(ContentSecurityPolicyConfig::DEFAULT)
       self.csp_report_only = OPT_OUT
       instance_eval &block if block_given?
     end
@@ -202,7 +202,7 @@ module SecureHeaders
       else
         new_csp = if new_csp.is_a?(ContentSecurityPolicyConfig)
           ContentSecurityPolicyReportOnlyConfig.new(new_csp.to_h)
-        elsif new_csp.is_a?(Hash)
+        else
           if new_csp[:report_only] == false
             Kernel.warn "#{Kernel.caller.first}: [DEPRECATION] `#csp_report_only=` was supplied a config with report_only: false. Use #csp="
           end

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -155,18 +155,6 @@ module SecureHeaders
       self.cached_headers[XFrameOptions::CONFIG_KEY] = XFrameOptions.make_header(value)
     end
 
-    # Public: generated cached headers for a specific user agent.
-    def rebuild_csp_header_cache!(user_agent, header_key)
-      self.cached_headers[header_key] = {}
-
-      csp = header_key == CSP::CONFIG_KEY ? self.csp : self.csp_report_only
-      unless csp == OPT_OUT
-        user_agent = UserAgent.parse(user_agent)
-        variation = CSP.ua_to_variation(user_agent)
-        self.cached_headers[header_key][variation] = CSP.make_header(csp, user_agent)
-      end
-    end
-
     # Public: validates all configurations values.
     #
     # Raises various configuration errors if any invalid config is detected.

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -201,10 +201,11 @@ module SecureHeaders
         elsif new_csp.respond_to?(:opt_out?)
           new_csp.dup
         else
-          if new_csp[:report_only] == false
-            Kernel.warn "#{Kernel.caller.first}: [DEPRECATION] `#csp_report_only=` was supplied a config with report_only: false. Use #csp="
+          if new_csp[:report_only] == false # nil is a valid value on which we do not want to raise
+            raise ContentSecurityPolicyConfigError, "`#csp_report_only=` was supplied a config with report_only: false. Use #csp="
+          else
+            ContentSecurityPolicyReportOnlyConfig.new(new_csp)
           end
-          ContentSecurityPolicyReportOnlyConfig.new(new_csp)
         end
       end
     end

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -122,7 +122,7 @@ module SecureHeaders
     def initialize(&block)
       self.hpkp = OPT_OUT
       self.referrer_policy = OPT_OUT
-      self.csp = self.class.send(:deep_copy, CSP::DEFAULT_CONFIG)
+      self.csp = OPT_OUT
       self.csp_report_only = OPT_OUT
       instance_eval &block if block_given?
     end

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -123,7 +123,7 @@ module SecureHeaders
     def initialize(&block)
       self.hpkp = OPT_OUT
       self.referrer_policy = OPT_OUT
-      self.csp = OPT_OUT
+      self.csp = ContentSecurityPolicyConfig::DEFAULT
       self.csp_report_only = OPT_OUT
       instance_eval &block if block_given?
     end
@@ -134,10 +134,8 @@ module SecureHeaders
     def dup
       copy = self.class.new
       copy.cookies = @cookies
-      copy.csp = self.class.send(:deep_copy_if_hash, @csp)
-      copy.dynamic_csp = self.class.send(:deep_copy_if_hash, @dynamic_csp)
-      copy.csp_report_only = self.class.send(:deep_copy_if_hash, @csp_report_only)
-      copy.dynamic_csp_report_only = self.class.send(:deep_copy_if_hash, @dynamic_csp_report_only)
+      copy.csp = @csp.dup
+      copy.csp_report_only = @csp_report_only.dup
       copy.cached_headers = self.class.send(:deep_copy_if_hash, @cached_headers)
       copy.x_content_type_options = @x_content_type_options
       copy.hsts = @hsts

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -16,6 +16,8 @@ module SecureHeaders
         else
           ContentSecurityPolicyConfig.new(config || DEFAULT_CONFIG)
         end
+      elsif config.nil?
+        ContentSecurityPolicyConfig.new(DEFAULT_CONFIG)
       else
         config
       end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -19,7 +19,7 @@ module SecureHeaders
       elsif config.nil?
         ContentSecurityPolicyConfig.new(DEFAULT_CONFIG)
       else
-        config
+        config.dup
       end
 
       @parsed_ua = if user_agent.is_a?(UserAgent::Browsers::Base)

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -37,11 +37,7 @@ module SecureHeaders
     # Returns the name to use for the header. Either "Content-Security-Policy" or
     # "Content-Security-Policy-Report-Only"
     def name
-      if @config.report_only?
-        REPORT_ONLY
-      else
-        HEADER_NAME
-      end
+      @config.class.const_get(:HEADER_NAME)
     end
 
     ##

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -81,10 +81,8 @@ module SecureHeaders
     # Returns a content security policy header value.
     def build_value
       directives.map do |directive_name|
-        puts directive_name
         case DIRECTIVE_VALUE_TYPES[directive_name]
         when :boolean
-          puts "   #{@config.directive_value(directive_name)}"
           symbol_to_hyphen_case(directive_name) if @config.directive_value(directive_name)
         when :string
           [symbol_to_hyphen_case(directive_name), @config.directive_value(directive_name)].join(" ")
@@ -112,7 +110,6 @@ module SecureHeaders
       else
         @config.directive_value(directive)
       end
-      puts "  #{directive}=#{source_list}"
       return unless source_list && source_list.any?
       normalized_source_list = minify_source_list(directive, source_list)
       [symbol_to_hyphen_case(directive), normalized_source_list].join(" ")

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -61,7 +61,7 @@ module SecureHeaders
     end
 
     def opt_out?
-      self == OPT_OUT
+      false
     end
 
     def ==(o)

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -107,6 +107,10 @@ module SecureHeaders
     def report_only?
       false
     end
+
+    def make_report_only
+      ContentSecurityPolicyReportOnlyConfig.new(self.to_h)
+    end
   end
 
   class ContentSecurityPolicyReportOnlyConfig < ContentSecurityPolicyConfig
@@ -115,6 +119,10 @@ module SecureHeaders
 
     def report_only?
       true
+    end
+
+    def make_report_only
+      self
     end
   end
 end

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -1,0 +1,67 @@
+module SecureHeaders
+  module DynamicConfig
+    def self.included(base)
+      base.send(:attr_reader, *base.attrs)
+      base.attrs.each do |attr|
+        base.send(:define_method, "#{attr}=") do |value|
+          if self.class.attrs.include?(attr)
+            if PolicyManagement::DIRECTIVE_VALUE_TYPES[k] == :source_list
+              instance_variable_set("@{k}=", value.dup)
+              self.send("#{attr}=", value.dup)
+            else
+              self.send("#{attr}=", value)
+            end
+          else
+            raise "Unknown config directive: #{attr}"
+          end
+
+          @modified = true
+        end
+      end
+    end
+
+    def initialize(hash)
+      hash.keys.map do |k|
+        next unless hash[k]
+        if self.class.attrs.include?(k)
+          if PolicyManagement::DIRECTIVE_VALUE_TYPES[k] == :source_list
+            self.send("#{k}=", hash[k].dup)
+          else
+            self.send("#{k}=", hash[k])
+          end
+        else
+          binding.pry
+          raise "Unknown config directive: #{k}"
+        end
+      end
+    end
+
+    def update_directive(directive, value)
+      if self.class.attrs.include?(directive)
+        if PolicyManagement::DIRECTIVE_VALUE_TYPES[k] == :source_list
+          instance_variable_set("@{k}=", hash[k].dup)
+        else
+          self.send("#{k}=", hash[k])
+        end
+      end
+
+
+    end
+
+    def directive_value(directive)
+      if self.class.attrs.include?(directive)
+        self.send(directive)
+      end
+    end
+  end
+
+  class ContentSecurityPolicyConfigError < StandardError; end
+  class ContentSecurityPolicyConfig
+    def self.attrs
+      PolicyManagement::ALL_DIRECTIVES + PolicyManagement::META_CONFIGS + PolicyManagement::NONCES
+    end
+
+    include DynamicConfig
+    alias_method :report_only?, :report_only
+  end
+end

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -60,6 +60,10 @@ module SecureHeaders
       self.class.new(self.to_h)
     end
 
+    def opt_out?
+      self == OPT_OUT
+    end
+
     def ==(o)
       self.class == o.class && self.to_h == o.to_h
     end

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -39,7 +39,7 @@ module SecureHeaders
     end
 
     def merge(new_hash)
-      CSP.combine_policies(self.to_h, new_hash)
+      ContentSecurityPolicy.combine_policies(self.to_h, new_hash)
     end
 
     def merge!(new_hash)
@@ -47,7 +47,7 @@ module SecureHeaders
     end
 
     def append(new_hash)
-      from_hash(CSP.combine_policies(self.to_h, new_hash))
+      from_hash(ContentSecurityPolicy.combine_policies(self.to_h, new_hash))
     end
 
     def to_h
@@ -85,6 +85,9 @@ module SecureHeaders
 
   class ContentSecurityPolicyConfigError < StandardError; end
   class ContentSecurityPolicyConfig
+    CONFIG_KEY = :csp
+    HEADER_NAME = "Content-Security-Policy".freeze
+
     def self.attrs
       PolicyManagement::ALL_DIRECTIVES + PolicyManagement::META_CONFIGS + PolicyManagement::NONCES
     end
@@ -107,6 +110,9 @@ module SecureHeaders
   end
 
   class ContentSecurityPolicyReportOnlyConfig < ContentSecurityPolicyConfig
+    CONFIG_KEY = :csp_report_only
+    HEADER_NAME = "Content-Security-Policy-Report-Only".freeze
+
     def report_only?
       true
     end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -163,6 +163,7 @@ module SecureHeaders
     }.freeze
 
     CONFIG_KEY = :csp
+    REPORT_ONLY_CONFIG_KEY = :csp_report_only
     STAR_REGEXP = Regexp.new(Regexp.escape(STAR))
     HTTP_SCHEME_REGEX = %r{\Ahttps?://}
 

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -156,7 +156,7 @@ module SecureHeaders
       PLUGIN_TYPES              => :source_list,
       REFLECTED_XSS             => :string,
       REPORT_URI                => :source_list,
-      SANDBOX                   => :string,
+      SANDBOX                   => :source_list,
       SCRIPT_SRC                => :source_list,
       STYLE_SRC                 => :source_list,
       UPGRADE_INSECURE_REQUESTS => :boolean
@@ -202,7 +202,9 @@ module SecureHeaders
       def validate_config!(config)
         return if config.nil? || config == OPT_OUT
         raise ContentSecurityPolicyConfigError.new(":default_src is required") unless config[:default_src]
-        config.each do |key, value|
+        ContentSecurityPolicyConfig.attrs.each do |key|
+          value = config.directive_value(key)
+          next unless value
           if META_CONFIGS.include?(key)
             raise ContentSecurityPolicyConfigError.new("#{key} must be a boolean value") unless boolean?(value) || value.nil?
           else

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -200,7 +200,7 @@ module SecureHeaders
       # Does not validate the invididual values of the source expression (e.g.
       # script_src => h*t*t*p: will not raise an exception)
       def validate_config!(config)
-        return if config.nil? || config == OPT_OUT
+        return if config.nil? || config.opt_out?
         raise ContentSecurityPolicyConfigError.new(":default_src is required") unless config.directive_value(:default_src)
         ContentSecurityPolicyConfig.attrs.each do |key|
           value = config.directive_value(key)

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -213,18 +213,6 @@ module SecureHeaders
         end
       end
 
-      # Public: determine if merging +additions+ will cause a change to the
-      # actual value of the config.
-      #
-      # e.g. config = { script_src: %w(example.org google.com)} and
-      # additions = { script_src: %w(google.com)} then idempotent_additions? would return
-      # because google.com is already in the config.
-      def idempotent_additions?(config, additions)
-        return true if config == OPT_OUT && additions == OPT_OUT
-        return false if config == OPT_OUT
-        config == combine_policies(config, additions)
-      end
-
       # Public: combine the values from two different configs.
       #
       # original - the main config

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -180,6 +180,11 @@ module SecureHeaders
       :preserve_schemes
     ].freeze
 
+    NONCES = [
+      :script_nonce,
+      :style_nonce
+    ].freeze
+
     module ClassMethods
       # Public: generate a header name, value array that is user-agent-aware.
       #

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -201,7 +201,7 @@ module SecureHeaders
       # script_src => h*t*t*p: will not raise an exception)
       def validate_config!(config)
         return if config.nil? || config == OPT_OUT
-        raise ContentSecurityPolicyConfigError.new(":default_src is required") unless config[:default_src]
+        raise ContentSecurityPolicyConfigError.new(":default_src is required") unless config.directive_value(:default_src)
         ContentSecurityPolicyConfig.attrs.each do |key|
           value = config.directive_value(key)
           next unless value
@@ -239,7 +239,7 @@ module SecureHeaders
       # 3. if a value in additions does exist in the original config, the two
       # values are joined.
       def combine_policies(original, additions)
-        if original == OPT_OUT
+        if original == {}
           raise ContentSecurityPolicyConfigError.new("Attempted to override an opt-out CSP config.")
         end
 

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -7,9 +7,6 @@ module SecureHeaders
     MODERN_BROWSERS = %w(Chrome Opera Firefox)
     DEFAULT_VALUE = "default-src https:".freeze
     DEFAULT_CONFIG = { default_src: %w(https:) }.freeze
-    HEADER_NAME = "Content-Security-Policy".freeze
-    REPORT_ONLY = "Content-Security-Policy-Report-Only".freeze
-    HEADER_NAMES = [HEADER_NAME, REPORT_ONLY]
     DATA_PROTOCOL = "data:".freeze
     BLOB_PROTOCOL = "blob:".freeze
     SELF = "'self'".freeze
@@ -162,8 +159,7 @@ module SecureHeaders
       UPGRADE_INSECURE_REQUESTS => :boolean
     }.freeze
 
-    CONFIG_KEY = :csp
-    REPORT_ONLY_CONFIG_KEY = :csp_report_only
+
     STAR_REGEXP = Regexp.new(Regexp.escape(STAR))
     HTTP_SCHEME_REGEX = %r{\Ahttps?://}
 

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -4,9 +4,7 @@ module SecureHeaders
   describe Configuration do
     before(:each) do
       reset_config
-      Configuration.default do |config|
-        config.csp = ContentSecurityPolicyConfig.new(:default_src => %w(https:))
-      end
+      Configuration.default
     end
 
     it "has a default config" do
@@ -38,8 +36,8 @@ module SecureHeaders
 
       config = Configuration.get(:test_override)
       noop = Configuration.get(Configuration::NOOP_CONFIGURATION)
-      [:csp, :dynamic_csp, :cookies].each do |key|
-        expect(config.send(key)).to eq(noop.send(key)), "Value not copied: #{key}."
+      [:csp, :csp_report_only, :cookies].each do |key|
+        expect(config.send(key)).to eq(noop.send(key))
       end
     end
 
@@ -67,7 +65,7 @@ module SecureHeaders
       default = Configuration.get
       override = Configuration.get(:override)
 
-      expect(override.csp).not_to eq(default.csp)
+      expect(override.csp.directive_value(:default_src)).not_to be(default.csp.directive_value(:default_src))
     end
 
     it "allows you to override an override" do
@@ -80,9 +78,9 @@ module SecureHeaders
       end
 
       original_override = Configuration.get(:override)
-      expect(original_override.csp).to eq(default_src: %w('self'))
+      expect(original_override.csp.to_h).to eq(default_src: %w('self'))
       override_config = Configuration.get(:second_override)
-      expect(override_config.csp).to eq(default_src: %w('self'), script_src: %w(example.org))
+      expect(override_config.csp.to_h).to eq(default_src: %w('self'), script_src: %w('self' example.org))
     end
 
     it "deprecates the secure_cookies configuration" do

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -4,7 +4,9 @@ module SecureHeaders
   describe Configuration do
     before(:each) do
       reset_config
-      Configuration.default
+      Configuration.default do |config|
+        config.csp = { default_src: %w(https:) }
+      end
     end
 
     it "has a default config" do

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -4,9 +4,7 @@ module SecureHeaders
   describe Configuration do
     before(:each) do
       reset_config
-      Configuration.default do |config|
-        config.csp = { default_src: %w(https:) }
-      end
+      Configuration.default
     end
 
     it "has a default config" do

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -4,7 +4,9 @@ module SecureHeaders
   describe Configuration do
     before(:each) do
       reset_config
-      Configuration.default
+      Configuration.default do |config|
+        config.csp = ContentSecurityPolicyConfig.new(:default_src => %w(https:))
+      end
     end
 
     it "has a default config" do

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -14,11 +14,11 @@ module SecureHeaders
 
     describe "#name" do
       context "when in report-only mode" do
-        specify { expect(ContentSecurityPolicy.new(default_opts.merge(report_only: true)).name).to eq(ContentSecurityPolicy::HEADER_NAME + "-Report-Only") }
+        specify { expect(ContentSecurityPolicy.new(default_opts.merge(report_only: true)).name).to eq(ContentSecurityPolicyReportOnlyConfig::HEADER_NAME) }
       end
 
       context "when in enforce mode" do
-        specify { expect(ContentSecurityPolicy.new(default_opts).name).to eq(ContentSecurityPolicy::HEADER_NAME) }
+        specify { expect(ContentSecurityPolicy.new(default_opts).name).to eq(ContentSecurityPolicyConfig::HEADER_NAME) }
       end
     end
 

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -177,19 +177,5 @@ module SecureHeaders
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
     end
-
-    describe "#idempotent_additions?" do
-      specify { expect(ContentSecurityPolicy.idempotent_additions?(OPT_OUT, script_src: %w(b.com))).to be false }
-      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w(c.com))).to be false }
-      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, style_src: %w(b.com))).to be false }
-      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w(a.com b.com c.com))).to be false }
-
-      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w(b.com))).to be true }
-      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w(b.com a.com))).to be true }
-      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: %w())).to be true }
-      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, script_src: [nil])).to be true }
-      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, style_src: [nil])).to be true }
-      specify { expect(ContentSecurityPolicy.idempotent_additions?({script_src: %w(a.com b.com)}, style_src: nil)).to be true }
-    end
   end
 end

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -108,7 +108,7 @@ module SecureHeaders
         end
         combined_config = ContentSecurityPolicy.combine_policies(Configuration.get.csp.to_h, script_src: %w(anothercdn.com))
         csp = ContentSecurityPolicy.new(combined_config)
-        expect(csp.name).to eq(CSP::HEADER_NAME)
+        expect(csp.name).to eq(ContentSecurityPolicyConfig::HEADER_NAME)
         expect(csp.value).to eq("default-src https:; script-src https: anothercdn.com")
       end
 

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -101,7 +101,12 @@ module SecureHeaders
 
     describe "#combine_policies" do
       it "combines the default-src value with the override if the directive was unconfigured" do
-        combined_config = CSP.combine_policies(Configuration.default.csp, script_src: %w(anothercdn.com))
+        Configuration.default do |config|
+          config.csp = {
+            default_src: %w(https:)
+          }
+        end
+        combined_config = CSP.combine_policies(Configuration.get.csp, script_src: %w(anothercdn.com))
         csp = ContentSecurityPolicy.new(combined_config)
         expect(csp.name).to eq(CSP::HEADER_NAME)
         expect(csp.value).to eq("default-src https:; script-src https: anothercdn.com")

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -40,61 +40,61 @@ module SecureHeaders
           report_uri: %w(https://example.com/uri-directive)
         }
 
-        CSP.validate_config!(config)
+        CSP.validate_config!(ContentSecurityPolicyConfig.new(config))
       end
 
       it "requires a :default_src value" do
         expect do
-          CSP.validate_config!(script_src: %('self'))
+          CSP.validate_config!(ContentSecurityPolicyConfig.new(script_src: %('self')))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
 
       it "requires :report_only to be a truthy value" do
         expect do
-          CSP.validate_config!(default_opts.merge(report_only: "steve"))
+          CSP.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(report_only: "steve")))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
 
       it "requires :preserve_schemes to be a truthy value" do
         expect do
-          CSP.validate_config!(default_opts.merge(preserve_schemes: "steve"))
+          CSP.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(preserve_schemes: "steve")))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
 
       it "requires :block_all_mixed_content to be a boolean value" do
         expect do
-          CSP.validate_config!(default_opts.merge(block_all_mixed_content: "steve"))
+          CSP.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(block_all_mixed_content: "steve")))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
 
       it "requires :upgrade_insecure_requests to be a boolean value" do
         expect do
-          CSP.validate_config!(default_opts.merge(upgrade_insecure_requests: "steve"))
+          CSP.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(upgrade_insecure_requests: "steve")))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
 
       it "requires all source lists to be an array of strings" do
         expect do
-          CSP.validate_config!(default_src: "steve")
+          CSP.validate_config!(ContentSecurityPolicyConfig.new(default_src: "steve"))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
 
       it "allows nil values" do
         expect do
-          CSP.validate_config!(default_src: %w('self'), script_src: ["https:", nil])
+          CSP.validate_config!(ContentSecurityPolicyConfig.new(default_src: %w('self'), script_src: ["https:", nil]))
         end.to_not raise_error
       end
 
       it "rejects unknown directives / config" do
         expect do
-          CSP.validate_config!(default_src: %w('self'), default_src_totally_mispelled: "steve")
+          CSP.validate_config!(ContentSecurityPolicyConfig.new(default_src: %w('self'), default_src_totally_mispelled: "steve"))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
 
       # this is mostly to ensure people don't use the antiquated shorthands common in other configs
       it "performs light validation on source lists" do
         expect do
-          CSP.validate_config!(default_src: %w(self none inline eval))
+          CSP.validate_config!(ContentSecurityPolicyConfig.new(default_src: %w(self none inline eval)))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
     end
@@ -106,7 +106,7 @@ module SecureHeaders
             default_src: %w(https:)
           }
         end
-        combined_config = CSP.combine_policies(Configuration.get.csp, script_src: %w(anothercdn.com))
+        combined_config = CSP.combine_policies(Configuration.get.csp.to_h, script_src: %w(anothercdn.com))
         csp = ContentSecurityPolicy.new(combined_config)
         expect(csp.name).to eq(CSP::HEADER_NAME)
         expect(csp.value).to eq("default-src https:; script-src https: anothercdn.com")
@@ -120,7 +120,7 @@ module SecureHeaders
           }.freeze
         end
         report_uri = "https://report-uri.io/asdf"
-        combined_config = CSP.combine_policies(Configuration.get.csp, report_uri: [report_uri])
+        combined_config = CSP.combine_policies(Configuration.get.csp.to_h, report_uri: [report_uri])
         csp = ContentSecurityPolicy.new(combined_config, USER_AGENTS[:firefox])
         expect(csp.value).to include("report-uri #{report_uri}")
       end
@@ -135,7 +135,7 @@ module SecureHeaders
         non_default_source_additions = CSP::NON_FETCH_SOURCES.each_with_object({}) do |directive, hash|
           hash[directive] = %w("http://example.org)
         end
-        combined_config = CSP.combine_policies(Configuration.get.csp, non_default_source_additions)
+        combined_config = CSP.combine_policies(Configuration.get.csp.to_h, non_default_source_additions)
 
         CSP::NON_FETCH_SOURCES.each do |directive|
           expect(combined_config[directive]).to eq(%w("http://example.org))
@@ -151,7 +151,7 @@ module SecureHeaders
             report_only: false
           }
         end
-        combined_config = CSP.combine_policies(Configuration.get.csp, report_only: true)
+        combined_config = CSP.combine_policies(Configuration.get.csp.to_h, report_only: true)
         csp = ContentSecurityPolicy.new(combined_config, USER_AGENTS[:firefox])
         expect(csp.name).to eq(CSP::REPORT_ONLY)
       end
@@ -163,7 +163,7 @@ module SecureHeaders
             block_all_mixed_content: false
           }
         end
-        combined_config = CSP.combine_policies(Configuration.get.csp, block_all_mixed_content: true)
+        combined_config = CSP.combine_policies(Configuration.get.csp.to_h, block_all_mixed_content: true)
         csp = ContentSecurityPolicy.new(combined_config)
         expect(csp.value).to eq("default-src https:; block-all-mixed-content")
       end
@@ -173,7 +173,7 @@ module SecureHeaders
           config.csp = OPT_OUT
         end
         expect do
-          CSP.combine_policies(Configuration.get.csp, script_src: %w(anothercdn.com))
+          CSP.combine_policies(Configuration.get.csp.to_h, script_src: %w(anothercdn.com))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
     end

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -51,7 +51,7 @@ module SecureHeaders
       SecureHeaders.use_secure_headers_override(request, "my_custom_config")
       expect(request.env[SECURE_HEADERS_CONFIG]).to be(Configuration.get("my_custom_config"))
       _, env = middleware.call request.env
-      expect(env[CSP::HEADER_NAME]).to match("example.org")
+      expect(env[ContentSecurityPolicyConfig::HEADER_NAME]).to match("example.org")
     end
 
     context "secure_cookies" do

--- a/spec/lib/secure_headers/view_helpers_spec.rb
+++ b/spec/lib/secure_headers/view_helpers_spec.rb
@@ -118,10 +118,10 @@ module SecureHeaders
         Message.new(request).result
         _, env = middleware.call request.env
 
-        expect(env[CSP::HEADER_NAME]).to match(/script-src[^;]*'#{Regexp.escape(expected_hash)}'/)
-        expect(env[CSP::HEADER_NAME]).to match(/script-src[^;]*'nonce-abc123'/)
-        expect(env[CSP::HEADER_NAME]).to match(/style-src[^;]*'nonce-abc123'/)
-        expect(env[CSP::HEADER_NAME]).to match(/style-src[^;]*'#{Regexp.escape(expected_style_hash)}'/)
+        expect(env[ContentSecurityPolicyConfig::HEADER_NAME]).to match(/script-src[^;]*'#{Regexp.escape(expected_hash)}'/)
+        expect(env[ContentSecurityPolicyConfig::HEADER_NAME]).to match(/script-src[^;]*'nonce-abc123'/)
+        expect(env[ContentSecurityPolicyConfig::HEADER_NAME]).to match(/style-src[^;]*'nonce-abc123'/)
+        expect(env[ContentSecurityPolicyConfig::HEADER_NAME]).to match(/style-src[^;]*'#{Regexp.escape(expected_style_hash)}'/)
       end
     end
   end

--- a/spec/lib/secure_headers/view_helpers_spec.rb
+++ b/spec/lib/secure_headers/view_helpers_spec.rb
@@ -72,8 +72,11 @@ module SecureHeaders
 
     before(:all) do
       Configuration.default do |config|
-        config.csp[:script_src] = %w('self')
-        config.csp[:style_src] = %w('self')
+        config.csp = {
+          :default_src => %w('self'),
+          :script_src => %w('self'),
+          :style_src => %w('self')
+        }
       end
     end
 

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -59,7 +59,20 @@ module SecureHeaders
       end
 
       it "allows you to opt out entirely" do
-        Configuration.default
+        # configure the disabled-by-default headers to ensure they also do not get set
+        Configuration.default do |config|
+          config.csp_report_only = { :default_src => ["example.com"] }
+          config.hpkp = {
+            report_only: false,
+            max_age: 10000000,
+            include_subdomains: true,
+            report_uri: "https://report-uri.io/example-hpkp",
+            pins: [
+              {sha256: "abc"},
+              {sha256: "123"}
+            ]
+          }
+        end
         SecureHeaders.opt_out_of_all_protection(request)
         hash = SecureHeaders.header_hash_for(request)
         ALL_HEADER_CLASSES.each do |klass|

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -105,6 +105,8 @@ module SecureHeaders
 
         hash = SecureHeaders.header_hash_for(firefox_request)
 
+        pp hash
+
         # child-src is translated to frame-src
         expect(hash[CSP::HEADER_NAME]).to eq("default-src 'self'; frame-src 'self'; script-src 'self'")
       end
@@ -188,6 +190,7 @@ module SecureHeaders
 
           SecureHeaders.append_content_security_policy_directives(request, script_src: %w(anothercdn.com))
           new_config = SecureHeaders.config_for(request)
+          $debug = true
           expect { new_config.send(:csp=, {}) }.to raise_error(Configuration::IllegalPolicyModificationError)
 
           expect do

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -16,7 +16,7 @@ module SecureHeaders
 
     it "raises a NotYetConfiguredError if trying to opt-out of unconfigured headers" do
       expect do
-        SecureHeaders.opt_out_of_header(request, CSP::CONFIG_KEY)
+        SecureHeaders.opt_out_of_header(request, ContentSecurityPolicyConfig::CONFIG_KEY)
       end.to raise_error(Configuration::NotYetConfiguredError)
     end
 
@@ -32,8 +32,8 @@ module SecureHeaders
         Configuration.default do |config|
           config.csp_report_only = { default_src: %w('self')} # no default value
         end
-        SecureHeaders.opt_out_of_header(request, CSP::CONFIG_KEY)
-        SecureHeaders.opt_out_of_header(request, CSPRO::CONFIG_KEY)
+        SecureHeaders.opt_out_of_header(request, ContentSecurityPolicyConfig::CONFIG_KEY)
+        SecureHeaders.opt_out_of_header(request, ContentSecurityPolicyReportOnlyConfig::CONFIG_KEY)
         SecureHeaders.opt_out_of_header(request, XContentTypeOptions::CONFIG_KEY)
         hash = SecureHeaders.header_hash_for(request)
         expect(hash['Content-Security-Policy-Report-Only']).to be_nil
@@ -98,7 +98,7 @@ module SecureHeaders
         SecureHeaders.override_content_security_policy_directives(request, default_src: %w(https:), script_src: %w('self'))
 
         hash = SecureHeaders.header_hash_for(request)
-        expect(hash[CSP::HEADER_NAME]).to eq("default-src https:; script-src 'self'")
+        expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src https:; script-src 'self'")
         expect(hash[XFrameOptions::HEADER_NAME]).to eq(XFrameOptions::SAMEORIGIN)
       end
 
@@ -119,7 +119,7 @@ module SecureHeaders
         hash = SecureHeaders.header_hash_for(firefox_request)
 
         # child-src is translated to frame-src
-        expect(hash[CSP::HEADER_NAME]).to eq("default-src 'self'; frame-src 'self'; script-src 'self'")
+        expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; frame-src 'self'; script-src 'self'")
       end
 
       it "produces a hash of headers with default config" do
@@ -164,7 +164,7 @@ module SecureHeaders
 
           SecureHeaders.append_content_security_policy_directives(request, script_src: %w(anothercdn.com))
           hash = SecureHeaders.header_hash_for(request)
-          expect(hash[CSP::HEADER_NAME]).to eq("default-src 'self'; script-src mycdn.com 'unsafe-inline' anothercdn.com")
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; script-src mycdn.com 'unsafe-inline' anothercdn.com")
         end
 
         it "overrides individual directives" do
@@ -175,7 +175,7 @@ module SecureHeaders
           end
           SecureHeaders.override_content_security_policy_directives(request, default_src: %w('none'))
           hash = SecureHeaders.header_hash_for(request)
-          expect(hash[CSP::HEADER_NAME]).to eq("default-src 'none'")
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'none'")
         end
 
         it "overrides non-existant directives" do
@@ -186,8 +186,8 @@ module SecureHeaders
           end
           SecureHeaders.override_content_security_policy_directives(request, img_src: [ContentSecurityPolicy::DATA_PROTOCOL])
           hash = SecureHeaders.header_hash_for(request)
-          expect(hash[CSPRO::HEADER_NAME]).to be_nil
-          expect(hash[CSP::HEADER_NAME]).to eq("default-src https:; img-src data:")
+          expect(hash[ContentSecurityPolicyReportOnlyConfig::HEADER_NAME]).to be_nil
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src https:; img-src data:")
         end
 
         it "does not append a nonce when the browser does not support it" do
@@ -202,7 +202,7 @@ module SecureHeaders
           safari_request = Rack::Request.new(request.env.merge("HTTP_USER_AGENT" => USER_AGENTS[:safari5]))
           nonce = SecureHeaders.content_security_policy_script_nonce(safari_request)
           hash = SecureHeaders.header_hash_for(safari_request)
-          expect(hash[CSP::HEADER_NAME]).to eq("default-src 'self'; script-src mycdn.com 'unsafe-inline'; style-src 'self'")
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; script-src mycdn.com 'unsafe-inline'; style-src 'self'")
         end
 
         it "appends a nonce to the script-src when used" do

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -244,6 +244,17 @@ module SecureHeaders
           expect(hash[ContentSecurityPolicyReportOnlyConfig::HEADER_NAME]).to eq("default-src 'self'")
         end
 
+        it "Raises an error if csp_report_only is used with `report_only: false`" do
+          expect do
+            Configuration.default do |config|
+              config.csp_report_only = {
+                default_src: %w('self'),
+                report_only: false
+              }
+            end
+          end.to raise_error(ContentSecurityPolicyConfigError)
+        end
+
         context "setting two headers" do
           before(:each) do
             Configuration.default do |config|

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -207,9 +207,14 @@ module SecureHeaders
         end
 
         it "overrides non-existant directives" do
-          Configuration.default
+          Configuration.default do |config|
+            config.csp = {
+              default_src: %w('self')
+            }
+          end
           SecureHeaders.override_content_security_policy_directives(request, img_src: [ContentSecurityPolicy::DATA_PROTOCOL])
           hash = SecureHeaders.header_hash_for(request)
+          puts hash
           expect(hash[CSP::HEADER_NAME]).to eq("default-src https:; img-src data:")
         end
 

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -33,7 +33,7 @@ module SecureHeaders
           config.csp_report_only = { default_src: %w('self')} # no default value
         end
         SecureHeaders.opt_out_of_header(request, CSP::CONFIG_KEY)
-        SecureHeaders.opt_out_of_header(request, CSP::REPORT_ONLY_CONFIG_KEY)
+        SecureHeaders.opt_out_of_header(request, CSPRO::CONFIG_KEY)
         SecureHeaders.opt_out_of_header(request, XContentTypeOptions::CONFIG_KEY)
         hash = SecureHeaders.header_hash_for(request)
         expect(hash['Content-Security-Policy-Report-Only']).to be_nil
@@ -186,7 +186,7 @@ module SecureHeaders
           end
           SecureHeaders.override_content_security_policy_directives(request, img_src: [ContentSecurityPolicy::DATA_PROTOCOL])
           hash = SecureHeaders.header_hash_for(request)
-          expect(hash[CSP::REPORT_ONLY]).to be_nil
+          expect(hash[CSPRO::HEADER_NAME]).to be_nil
           expect(hash[CSP::HEADER_NAME]).to eq("default-src https:; img-src data:")
         end
 
@@ -367,7 +367,7 @@ module SecureHeaders
       it "validates your csp config upon configuration" do
         expect do
           Configuration.default do |config|
-            config.csp = { CSP::DEFAULT_SRC => '123456' }
+            config.csp = { ContentSecurityPolicy::DEFAULT_SRC => '123456' }
           end
         end.to raise_error(ContentSecurityPolicyConfigError)
       end

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -99,13 +99,11 @@ module SecureHeaders
         firefox_request = Rack::Request.new(request.env.merge("HTTP_USER_AGENT" => USER_AGENTS[:firefox]))
 
         # append an unsupported directive
-        SecureHeaders.override_content_security_policy_directives(firefox_request, {plugin_types: %w(flash)}, :enforced)
+        SecureHeaders.override_content_security_policy_directives(firefox_request, {plugin_types: %w(flash)})
         # append a supported directive
-        SecureHeaders.override_content_security_policy_directives(firefox_request, {script_src: %w('self')}, :enforced)
+        SecureHeaders.override_content_security_policy_directives(firefox_request, {script_src: %w('self')})
 
         hash = SecureHeaders.header_hash_for(firefox_request)
-
-        pp hash
 
         # child-src is translated to frame-src
         expect(hash[CSP::HEADER_NAME]).to eq("default-src 'self'; frame-src 'self'; script-src 'self'")

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -226,6 +226,24 @@ module SecureHeaders
           expect(hash['Content-Security-Policy']).to eq("default-src 'self'; script-src mycdn.com 'nonce-#{nonce}'; style-src 'self'")
         end
 
+        it "supports the deprecated `report_only: true` format" do
+          expect(Kernel).to receive(:warn).once
+
+          Configuration.default do |config|
+            config.csp = {
+              default_src: %w('self'),
+              report_only: true
+            }
+          end
+
+          expect(Configuration.get.csp).to eq(OPT_OUT)
+          expect(Configuration.get.csp_report_only).to be_a(ContentSecurityPolicyReportOnlyConfig)
+
+          hash = SecureHeaders.header_hash_for(request)
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to be_nil
+          expect(hash[ContentSecurityPolicyReportOnlyConfig::HEADER_NAME]).to eq("default-src 'self'")
+        end
+
         context "setting two headers" do
           before(:each) do
             Configuration.default do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ USER_AGENTS = {
 }
 
 def expect_default_values(hash)
-  expect(hash[SecureHeaders::CSP::HEADER_NAME]).to be(nil)
+  expect(hash[SecureHeaders::CSP::HEADER_NAME]).to be("default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline'")
   expect(hash[SecureHeaders::XFrameOptions::HEADER_NAME]).to eq(SecureHeaders::XFrameOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::XDownloadOptions::HEADER_NAME]).to eq(SecureHeaders::XDownloadOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::StrictTransportSecurity::HEADER_NAME]).to eq(SecureHeaders::StrictTransportSecurity::DEFAULT_VALUE)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ USER_AGENTS = {
 }
 
 def expect_default_values(hash)
+  expect(hash[SecureHeaders::CSP::HEADER_NAME]).to be(nil)
   expect(hash[SecureHeaders::XFrameOptions::HEADER_NAME]).to eq(SecureHeaders::XFrameOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::XDownloadOptions::HEADER_NAME]).to eq(SecureHeaders::XDownloadOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::StrictTransportSecurity::HEADER_NAME]).to eq(SecureHeaders::StrictTransportSecurity::DEFAULT_VALUE)
@@ -32,7 +33,6 @@ def expect_default_values(hash)
   expect(hash[SecureHeaders::XContentTypeOptions::HEADER_NAME]).to eq(SecureHeaders::XContentTypeOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::XPermittedCrossDomainPolicies::HEADER_NAME]).to eq(SecureHeaders::XPermittedCrossDomainPolicies::DEFAULT_VALUE)
   expect(hash[SecureHeaders::ReferrerPolicy::HEADER_NAME]).to be_nil
-  expect(hash[SecureHeaders::CSP::HEADER_NAME]).to be(nil)
 end
 
 module SecureHeaders

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ USER_AGENTS = {
 }
 
 def expect_default_values(hash)
-  expect(hash[SecureHeaders::CSP::HEADER_NAME]).to be("default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline'")
+  expect(hash[SecureHeaders::CSP::HEADER_NAME]).to eq("default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline'")
   expect(hash[SecureHeaders::XFrameOptions::HEADER_NAME]).to eq(SecureHeaders::XFrameOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::XDownloadOptions::HEADER_NAME]).to eq(SecureHeaders::XDownloadOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::StrictTransportSecurity::HEADER_NAME]).to eq(SecureHeaders::StrictTransportSecurity::DEFAULT_VALUE)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ USER_AGENTS = {
 }
 
 def expect_default_values(hash)
-  expect(hash[SecureHeaders::CSP::HEADER_NAME]).to eq("default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline'")
+  expect(hash[SecureHeaders::ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline'")
   expect(hash[SecureHeaders::XFrameOptions::HEADER_NAME]).to eq(SecureHeaders::XFrameOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::XDownloadOptions::HEADER_NAME]).to eq(SecureHeaders::XDownloadOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::StrictTransportSecurity::HEADER_NAME]).to eq(SecureHeaders::StrictTransportSecurity::DEFAULT_VALUE)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,6 @@ USER_AGENTS = {
 }
 
 def expect_default_values(hash)
-  expect(hash[SecureHeaders::CSP::HEADER_NAME]).to eq(SecureHeaders::CSP::DEFAULT_VALUE)
   expect(hash[SecureHeaders::XFrameOptions::HEADER_NAME]).to eq(SecureHeaders::XFrameOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::XDownloadOptions::HEADER_NAME]).to eq(SecureHeaders::XDownloadOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::StrictTransportSecurity::HEADER_NAME]).to eq(SecureHeaders::StrictTransportSecurity::DEFAULT_VALUE)
@@ -33,6 +32,7 @@ def expect_default_values(hash)
   expect(hash[SecureHeaders::XContentTypeOptions::HEADER_NAME]).to eq(SecureHeaders::XContentTypeOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::XPermittedCrossDomainPolicies::HEADER_NAME]).to eq(SecureHeaders::XPermittedCrossDomainPolicies::DEFAULT_VALUE)
   expect(hash[SecureHeaders::ReferrerPolicy::HEADER_NAME]).to be_nil
+  expect(hash[SecureHeaders::CSP::HEADER_NAME]).to be(nil)
 end
 
 module SecureHeaders


### PR DESCRIPTION
Fixes #256, #281
* [x] `@modified` bit strategy isn't working perfectly, I'm seeing objects being created when policies are not modified.
* [x] Has tests
* [x] Documentation updated

Setting two headers has been an often requested feature that has always had a workaround but was never a first class feature. This PR allows setting both headers.

In the process of supporting both, I decided to move away from hash-backed configs and towards class-based configs - mostly because it made debugging things very hard and mistyping a hash key is far to easy. This has the added benefit of not having to perform "deep clones" all the time and relying on hash voodoo. This is much clearer even if some of the operations are just glorified hash operations. 

This also adds a `@modified` attribute which signals whether the cached headers can be used or not. This removes the need to track a `dynamic_csp`, choose between two configs, and use the `idempotent_operations` call which was all just a bit too funky and created the need for a lot of boilerplate code.

When writing support for `override_content_security_policy_directives/append_content_security_policy_directives`, I realized that the default policy is not very user-friendly and insecure at the same time. Updating the default policy should make it easier for people to use the default setting and make their policy dynamic as needed. The new policy is less restrictive for the most part, with the exception of `object-src 'none'` which is just an unsafe default.

The reason the `DynamicConfig` stuff is extracted into a module with some hackery is so that it can be reused when implementing [FeaturePolicy](https://github.com/twitter/secureheaders/issues/275) which will benefit from the dynamic helper functions and non-hash-backed data. I like the idea, but the implementation looks a bit janky. I'll look into how ActiveRecord handles it's `changed?` function. I'm also questioning the use of `update_directive`/`directive_value`.
