### PR TITLE
add support for named appends

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,61 @@ use SecureHeaders::Middleware
 
 All headers except for PublicKeyPins have a default value. See the [corresponding classes for their defaults](https://github.com/twitter/secureheaders/tree/master/lib/secure_headers/headers).
 
+## Named Appends
+
+Named Appends are blocks of code that can be reused and composed during requests. e.g. If a certain partial is rendered conditionally, and the csp needs to be adjusted for that partial, you can create a named append for that situation. The value returned by the block will be passed into `append_content_security_policy_directives`. The current request object is passed as an argument to the block for even more flexibility.
+
+```ruby
+def show
+  if include_widget?
+    @widget = widget.render
+    use_content_security_policy_named_append(:widget_partial)
+  end
+end
+
+
+SecureHeaders::Configuration.named_append(:widget_partial) do |request|
+  if request.controller_instance.current_user.in_test_bucket?
+    { child_src: %w(beta.thirdpartyhost.com) }
+  else
+    { child_src: %w(thirdpartyhost.com) }
+  end
+end
+```
+
+You can use as many named appends as you would like per request, but be careful because order of inclusion matters. Consider the following:
+
+```ruby
+SecureHeader::Configuration.default do |config|
+  config.csp = { default_src: %w('self')}
+end
+
+SecureHeaders::Configuration.named_append(:A) do |request|
+  { default_src: %w(myhost.com) }
+end
+
+SecureHeaders::Configuration.named_append(:B) do |request|
+  { script_src: %w('unsafe-eval') }
+end
+```
+
+The following code will produce different policies due to the way policies are normalized (e.g. providing a previously undefined directive that inherits from `default-src`, removing host source values when `*` is provided. Removing `'none'` when additional values are present, etc.):
+
+```ruby
+def index
+  use_content_security_policy_named_append(:A)
+  use_content_security_policy_named_append(:B)
+  # produces default-src 'self' myhost.com; script-src 'self' myhost.com 'unsafe-eval';
+end
+
+def show
+  use_content_security_policy_named_append(:B)
+  use_content_security_policy_named_append(:A)
+  # produces default-src 'self' myhost.com; script-src 'self' 'unsafe-eval';
+end
+```
+
+
 ## Named overrides
 
 Named overrides serve two purposes:

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -72,6 +72,11 @@ module SecureHeaders
       override_secure_headers_request_config(request, config)
     end
 
+    def use_content_security_policy_named_append(request, name)
+      additions = SecureHeaders::Configuration.named_appends(name).call(request)
+      append_content_security_policy_directives(request, additions)
+    end
+
     # Public: override X-Frame-Options settings for this request.
     #
     # value - deny, sameorigin, or allowall
@@ -266,5 +271,9 @@ module SecureHeaders
 
   def override_x_frame_options(value)
     SecureHeaders.override_x_frame_options(request, value)
+  end
+
+  def use_content_security_policy_named_append(name)
+    SecureHeaders.use_content_security_policy_named_append(request, name)
   end
 end

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -7,8 +7,6 @@ module SecureHeaders
     class NotYetConfiguredError < StandardError; end
     class IllegalPolicyModificationError < StandardError; end
     class << self
-      @@appends = {}
-
       # Public: Set the global default configuration.
       #
       # Optionally supply a block to override the defaults set by this library.
@@ -49,12 +47,14 @@ module SecureHeaders
       end
 
       def named_appends(name)
-        @@appends[name]
+        @appends ||= {}
+        @appends[name]
       end
 
       def named_append(name, target = nil, &block)
+        @appends ||= {}
         raise "Provide a configuration block" unless block_given?
-        @@appends[name] = block
+        @appends[name] = block
       end
 
       private

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -7,6 +7,8 @@ module SecureHeaders
     class NotYetConfiguredError < StandardError; end
     class IllegalPolicyModificationError < StandardError; end
     class << self
+      @@appends = {}
+
       # Public: Set the global default configuration.
       #
       # Optionally supply a block to override the defaults set by this library.
@@ -44,6 +46,15 @@ module SecureHeaders
           raise NotYetConfiguredError, "Default policy not yet supplied"
         end
         @configurations[name]
+      end
+
+      def named_appends(name)
+        @@appends[name]
+      end
+
+      def named_append(name, target = nil, &block)
+        raise "Provide a configuration block" unless block_given?
+        @@appends[name] = block
       end
 
       private


### PR DESCRIPTION
Fixes #250
## All PRs:

* [x] Has tests
* [x] Documentation updated

@reedloden was this what you had in mind?

This allows you to define blocks of code that produce a hash of additions to be added to the CSP for a given request. The current request object is passed to the block. The result of the hash is passed to `append_content_security_policy_directives`.

The use case _usually_ is related to loosening a policy's restrictions. While we do provide `SecureHeaders::Configuration.override` blocks, something like this may be useful with `override_content_security_policy_directives` as well. I think that the demand for override support like this is pretty rare so I'll wait until there's a need. One example I can think of would be needing to override a directive with `'none'`, but chances are anything that needs to be set to `none` would be set in the default config.

Example use:

```ruby
def show
  if include_widget?
    @widget = widget.render
    use_content_security_policy_named_append(:widget_partial)
  end
end


SecureHeaders::Configuration.named_append(:widget_partial) do |request|
  if request.controller_instance.current_user.in_test_bucket?
    { child_src: %w(beta.thirdpartyhost.com) }
  else
    { child_src: %w(thirdpartyhost.com) }
  end
end
```

Blocked by #281 - This feature needs to be aware of the `csp`/`csp_report_only` config separation and needs to support the `target` attribute.



