### PR TITLE
restrict term-ansicolor so it works on 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
   gem "rack", "~> 1"
   gem "rspec"
   gem "coveralls"
+  gem "term-ansicolor", "< 1.4"
 end
 
 group :guard do


### PR DESCRIPTION
This might fix the issues @lalithr95 is running into in https://github.com/twitter/secureheaders/pull/290 