### PR TITLE
safari 10 supports nonces

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -8,6 +8,7 @@ module SecureHeaders
 
     # constants to be used for version-specific UA sniffing
     VERSION_46 = ::UserAgent::Version.new("46")
+    VERSION_10 = ::UserAgent::Version.new("10")
 
     def initialize(config = nil, user_agent = OTHER)
       @config = if config.is_a?(Hash)
@@ -223,7 +224,8 @@ module SecureHeaders
     end
 
     def nonces_supported?
-      @nonces_supported ||= MODERN_BROWSERS.include?(@parsed_ua.browser)
+      @nonces_supported ||= MODERN_BROWSERS.include?(@parsed_ua.browser) ||
+        @parsed_ua.browser == "Safari" && @parsed_ua.version >= VERSION_10
     end
 
     def symbol_to_hyphen_case(sym)

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -277,6 +277,20 @@ module SecureHeaders
           expect(hash['Content-Security-Policy']).to eq("default-src 'self'; script-src mycdn.com 'nonce-#{nonce}'; style-src 'self'")
         end
 
+        it "uses a nonce for safari 10+" do
+          Configuration.default do |config|
+            config.csp = {
+              default_src: %w('self'),
+              script_src: %w(mycdn.com)
+            }
+          end
+
+          safari_request = Rack::Request.new(request.env.merge("HTTP_USER_AGENT" => USER_AGENTS[:safari10]))
+          nonce = SecureHeaders.content_security_policy_script_nonce(safari_request)
+          hash = SecureHeaders.header_hash_for(safari_request)
+          expect(hash['Content-Security-Policy']).to eq("default-src 'self'; script-src mycdn.com 'nonce-#{nonce}'")
+        end
+
         it "supports the deprecated `report_only: true` format" do
           expect(Kernel).to receive(:warn).once
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,8 @@ USER_AGENTS = {
   ios6: "Mozilla/5.0 (iPhone; CPU iPhone OS 614 like Mac OS X) AppleWebKit/536.26 (KHTML like Gecko) Version/6.0 Mobile/10B350 Safari/8536.25",
   safari5: "Mozilla/5.0 (iPad; CPU OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko ) Version/5.1 Mobile/9B176 Safari/7534.48.3",
   safari5_1: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_3) AppleWebKit/534.55.3 (KHTML, like Gecko) Version/5.1.3 Safari/534.53.10",
-  safari6: "Mozilla/5.0 (Macintosh; Intel Mac OS X 1084) AppleWebKit/536.30.1 (KHTML like Gecko) Version/6.0.5 Safari/536.30.1"
+  safari6: "Mozilla/5.0 (Macintosh; Intel Mac OS X 1084) AppleWebKit/536.30.1 (KHTML like Gecko) Version/6.0.5 Safari/536.30.1",
+  safari10: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_1) AppleWebKit/602.2.11 (KHTML, like Gecko) Version/10.0.1 Safari/602.2.11"
 }
 
 def expect_default_values(hash)


### PR DESCRIPTION
Use CSP nonces for Safari 10+ responses.

