### PR TITLE
make the nonce support helper method public

### DIFF
--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -47,6 +47,7 @@ module SecureHeaders
   SECURE_HEADERS_CONFIG = "secure_headers_request_config".freeze
   NONCE_KEY = "secure_headers_content_security_policy_nonce".freeze
   HTTPS = "https".freeze
+  CSP = ContentSecurityPolicy
 
   ALL_HEADER_CLASSES = [
     ContentSecurityPolicyConfig,

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -224,8 +224,7 @@ module SecureHeaders
     end
 
     def nonces_supported?
-      @nonces_supported ||= MODERN_BROWSERS.include?(@parsed_ua.browser) ||
-        @parsed_ua.browser == "Safari" && @parsed_ua.version >= VERSION_10
+      @nonces_supported ||= self.class.nonces_supported?(@parsed_ua)
     end
 
     def symbol_to_hyphen_case(sym)

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -211,6 +211,15 @@ module SecureHeaders
         end
       end
 
+      # Public: check if a user agent supports CSP nonces
+      #
+      # user_agent - a String or a UserAgent object
+      def nonces_supported?(user_agent)
+        user_agent = UserAgent.parse(user_agent) if user_agent.is_a?(String)
+        MODERN_BROWSERS.include?(user_agent.browser) ||
+          user_agent.browser == "Safari" && user_agent.version >= CSP::VERSION_10
+      end
+
       # Public: combine the values from two different configs.
       #
       # original - the main config


### PR DESCRIPTION
Because this is helpful outside of SecureHeaders too.

This also re-adds `CSP = ContentSecurityPolicy` so you can references constants via `SecureHeaders::CSP`.