### PR TITLE
useragent gem version pinning

### DIFF
--- a/secure_headers.gemspec
+++ b/secure_headers.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.add_development_dependency "rake"
-  gem.add_dependency "useragent"
+  gem.add_dependency "useragent", "0.16.8"
 end


### PR DESCRIPTION
If the `useragent` version is too low, parsing user agents based on a
string like `"Chrome"` will not populate the version which is required
for other logic. Pinning the version will prevent random crashes from
not having the right version.