### PR TITLE
handle null useragent version

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -9,6 +9,7 @@ module SecureHeaders
     # constants to be used for version-specific UA sniffing
     VERSION_46 = ::UserAgent::Version.new("46")
     VERSION_10 = ::UserAgent::Version.new("10")
+    FALLBACK_VERSION = ::UserAgent::Version.new("0")
 
     def initialize(config = nil, user_agent = OTHER)
       @config = if config.is_a?(Hash)
@@ -213,7 +214,7 @@ module SecureHeaders
     # Returns an array of symbols representing the directives.
     def supported_directives
       @supported_directives ||= if VARIATIONS[@parsed_ua.browser]
-        if @parsed_ua.browser == "Firefox" && @parsed_ua.version >= VERSION_46
+        if @parsed_ua.browser == "Firefox" && ((@parsed_ua.version || FALLBACK_VERSION) >= VERSION_46)
           VARIATIONS["FirefoxTransitional"]
         else
           VARIATIONS[@parsed_ua.browser]

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -217,7 +217,7 @@ module SecureHeaders
       def nonces_supported?(user_agent)
         user_agent = UserAgent.parse(user_agent) if user_agent.is_a?(String)
         MODERN_BROWSERS.include?(user_agent.browser) ||
-          user_agent.browser == "Safari" && user_agent.version >= CSP::VERSION_10
+          user_agent.browser == "Safari" && (user_agent.version || CSP::FALLBACK_VERSION) >= CSP::VERSION_10
       end
 
       # Public: combine the values from two different configs.

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -149,6 +149,13 @@ module SecureHeaders
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:safari6])
           expect(policy.value).to eq("default-src default-src.com; connect-src connect-src.com; font-src font-src.com; frame-src child-src.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; sandbox sandbox.com; script-src script-src.com 'unsafe-inline'; style-src style-src.com; report-uri report-uri.com")
         end
+
+        it "falls back to standard Firefox defaults when the useragent version is not present" do
+          ua = USER_AGENTS[:firefox].dup
+          allow(ua).to receive(:version).and_return(nil)
+          policy = ContentSecurityPolicy.new(complex_opts, ua)
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; frame-src child-src.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
+        end
       end
     end
   end


### PR DESCRIPTION
## All PRs:

* [X] Has tests
* [X] Documentation updated (Not applicable)

This is a potential fix for #299, I'm not too familiar with useragent versioning but this seems like it will work. I've tested it against `0.10.0` which is mentioned in the issue.

I'm also not really loving `VERSION_NIL` as a constant name but couldn't think of anything better. 🤔 