### PR TITLE
quick and dirty strict-dynamic support'

### DIFF
--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -14,6 +14,7 @@ module SecureHeaders
     STAR = "*".freeze
     UNSAFE_INLINE = "'unsafe-inline'".freeze
     UNSAFE_EVAL = "'unsafe-eval'".freeze
+    STRICT_DYNAMIC = "'strict-dynamic'".freeze
 
     # leftover deprecated values that will be in common use upon upgrading.
     DEPRECATED_SOURCE_VALUES = [SELF, NONE, UNSAFE_EVAL, UNSAFE_INLINE, "inline", "eval"].map { |value| value.delete("'") }.freeze

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -107,6 +107,11 @@ module SecureHeaders
         expect(firefox_transitional).not_to match(/frame-src/)
       end
 
+      it "supports strict-dynamic" do
+        csp = ContentSecurityPolicy.new({default_src: %w('self'), script_src: [ContentSecurityPolicy::STRICT_DYNAMIC], script_nonce: 123456}, USER_AGENTS[:chrome])
+        expect(csp.value).to eq("default-src 'self'; script-src 'strict-dynamic' 'nonce-123456'")
+      end
+
       context "browser sniffing" do
         let (:complex_opts) do
           (ContentSecurityPolicy::ALL_DIRECTIVES - [:frame_src]).each_with_object({}) do |directive, hash|


### PR DESCRIPTION
Fixes #302 (don't fix it, just a partial implementation)

## All PRs:

* [x] Has tests
* [x] Documentation updated N/A

`'strict-dynamic'` was always supported since we don't do strict validation on source lists. This PR adds a constant and a test using it.

I chose not to add strict browser sniffing for now so UAs that don't support it might spit out an error message. The browser sniffing around nonces ensures that `strict-dynamic` + `nonce` will safely fallback to `unsafe-inline` when nonces aren't known to be supported.

Once I have information on how widely this is supported, I'll go back and add the sniffing to exclude the `strict-dynamic` from policies when unsupported. 



