### PR TITLE
Remove `preload` from the default HSTS configuration in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ SecureHeaders::Configuration.default do |config|
       lax: true # mark all cookies as SameSite=lax
     }
   }
-  config.hsts = "max-age=#{20.years.to_i}; includeSubdomains; preload"
+  # Add "; preload" and submit the site to hstspreload.org for best protection.
+  config.hsts = "max-age=#{20.years.to_i}; includeSubdomains"
   config.x_frame_options = "DENY"
   config.x_content_type_options = "nosniff"
   config.x_xss_protection = "1; mode=block"


### PR DESCRIPTION
See https://hstspreload.org/#opt-in

## All PRs:

* [ ] Has tests
* [X] Documentation updated
