### PR TITLE
Added CSP2 support for Safari 10+

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -216,6 +216,8 @@ module SecureHeaders
       @supported_directives ||= if VARIATIONS[@parsed_ua.browser]
         if @parsed_ua.browser == "Firefox" && ((@parsed_ua.version || FALLBACK_VERSION) >= VERSION_46)
           VARIATIONS["FirefoxTransitional"]
+        elsif @parsed_ua.browser == "Safari" && ((@parsed_ua.version || FALLBACK_VERSION) >= VERSION_10)
+          VARIATIONS["SafariTransitional"]
         else
           VARIATIONS[@parsed_ua.browser]
         end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -81,6 +81,7 @@ module SecureHeaders
 
     EDGE_DIRECTIVES = DIRECTIVES_1_0
     SAFARI_DIRECTIVES = DIRECTIVES_1_0
+    SAFARI_10_DIRECTIVES = DIRECTIVES_2_0
 
     FIREFOX_UNSUPPORTED_DIRECTIVES = [
       BLOCK_ALL_MIXED_CONTENT,
@@ -133,6 +134,7 @@ module SecureHeaders
       "Firefox" => FIREFOX_DIRECTIVES,
       "FirefoxTransitional" => FIREFOX_46_DIRECTIVES,
       "Safari" => SAFARI_DIRECTIVES,
+      "SafariTransitional" => SAFARI_10_DIRECTIVES,
       "Edge" => EDGE_DIRECTIVES,
       "Other" => CHROME_DIRECTIVES
     }.freeze

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -155,6 +155,11 @@ module SecureHeaders
           expect(policy.value).to eq("default-src default-src.com; connect-src connect-src.com; font-src font-src.com; frame-src child-src.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; sandbox sandbox.com; script-src script-src.com 'unsafe-inline'; style-src style-src.com; report-uri report-uri.com")
         end
 
+        it "adds 'unsafe-inline', filters  blocked-all-mixed-content, upgrade-insecure-requests, nonce sources, and hash sources for safari 10 and higher" do
+          policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:safari10])
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; plugin-types plugin-types.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; report-uri report-uri.com")
+        end
+
         it "falls back to standard Firefox defaults when the useragent version is not present" do
           ua = USER_AGENTS[:firefox].dup
           allow(ua).to receive(:version).and_return(nil)


### PR DESCRIPTION
## All PRs:

* [x] Has tests

Safari starting version 10 [added support for CSP2](https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_0.html).
