### PR TITLE
remove deprecation warning about frame_src

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -59,8 +59,6 @@ module SecureHeaders
     def normalize_child_frame_src
       if @config.frame_src && @config.child_src && @config.frame_src != @config.child_src
         Kernel.warn("#{Kernel.caller.first}: [DEPRECATION] both :child_src and :frame_src supplied and do not match. This can lead to inconsistent behavior across browsers.")
-      elsif @config.frame_src
-        Kernel.warn("#{Kernel.caller.first}: [DEPRECATION] :frame_src is deprecated, use :child_src instead. Provided: #{@config.frame_src}.")
       end
 
       if supported_directives.include?(:child_src)

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -86,8 +86,8 @@ module SecureHeaders
         expect(csp.value).to eq("default-src example.org")
       end
 
-      it "emits a warning when using frame-src" do
-        expect(Kernel).to receive(:warn).with(/:frame_src is deprecated, use :child_src instead./)
+      it "does not emit a warning when using frame-src" do
+        expect(Kernel).to_not receive(:warn)
         ContentSecurityPolicy.new(default_src: %w('self'), frame_src: %w('self')).value
       end
 


### PR DESCRIPTION
`frame-src` was un-deprecated: https://w3c.github.io/webappsec-csp/#changes-from-level-2

Therefore I think this warning should be removed.

## All PRs:

* [ ✔️  ] Has tests
* [n/a?] Documentation updated
