### PR TITLE
prevent loss of frame_src/child_src when using append_content_securit…

### DIFF
--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -278,13 +278,19 @@ module SecureHeaders
             if nonce_added?(original, additions)
               inferred_directive = directive.to_s.gsub(/_nonce/, "_src").to_sym
               unless original[inferred_directive] || NON_FETCH_SOURCES.include?(inferred_directive)
-                original[inferred_directive] = original[:default_src]
+                original[inferred_directive] = default_for(directive, original)
               end
             else
-              original[directive] = original[:default_src]
+              original[directive] = default_for(directive, original)
             end
           end
         end
+      end
+
+      def default_for(directive, original)
+        return original[FRAME_SRC] if directive == CHILD_SRC && original[FRAME_SRC]
+        return original[CHILD_SRC] if directive == FRAME_SRC && original[CHILD_SRC]
+        original[DEFAULT_SRC]
       end
 
       def nonce_added?(original, additions)

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -173,6 +173,33 @@ module SecureHeaders
           expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; script-src mycdn.com 'unsafe-inline' anothercdn.com")
         end
 
+        it "appends child-src to frame-src" do
+          Configuration.default do |config|
+            config.csp = {
+              default_src: %w('self'),
+              frame_src: %w(frame_src.com)
+            }
+          end
+
+          SecureHeaders.append_content_security_policy_directives(chrome_request, child_src: %w(child_src.com))
+          hash = SecureHeaders.header_hash_for(chrome_request)
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; child-src frame_src.com child_src.com")
+        end
+
+        it "appends frame-src to child-src" do
+          Configuration.default do |config|
+            config.csp = {
+              default_src: %w('self'),
+              child_src: %w(child_src.com)
+            }
+          end
+
+          safari_request = Rack::Request.new(request.env.merge("HTTP_USER_AGENT" => USER_AGENTS[:safari6]))
+          SecureHeaders.append_content_security_policy_directives(safari_request, frame_src: %w(frame_src.com))
+          hash = SecureHeaders.header_hash_for(safari_request)
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; frame-src child_src.com frame_src.com")
+        end
+
         it "supports named appends" do
           Configuration.default do |config|
             config.csp = {


### PR DESCRIPTION
…y_policy_directives

Currently it is possible for `frame_src` and `child_src` settings to be dropped when using `append_content_security_policy_directives`.

To reproduce: 

1. Set a `frame_src`
2. Override the `child_src` using `append_content_security_policy_directives`
3. Load the headers using a browser that will receive `child_src` from secureheaders, such as Chrome

Expected: the `child_src` is defaulted to the `frame_src` setting I have, plus the additions I made using `append_content_security_policy_directives`. I have this expectation because the gem promises to intelligently select between `child_src` and `frame_src`.

Actual: In this case, the original `frame_src` settings are dropped, and the `child_src` setting is `default_src` + `my additions`.

## All PRs:

* [x] Has tests
* [ ] Documentation updated
