### PR TITLE
Enable verbose mode in tests

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --order rand
+--warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please note that this project is released with a [Contributor Code of Conduct][c
 0. Configure and install the dependencies: `bundle install`
 0. Make sure the tests pass on your machine: `bundle exec rspec spec`
 0. Create a new branch: `git checkout -b my-branch-name`
-0. Make your change, add tests, and make sure the tests still pass
+0. Make your change, add tests, and make sure the tests still pass and that no warnings are raised
 0. Push to your fork and [submit a pull request][pr]
 0. Pat your self on the back and wait for your pull request to be reviewed and merged.
 
@@ -25,7 +25,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
 - Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
-## Releasing 
+## Releasing
 
 0. Ensure CI is green
 0. Pull the latest code
@@ -39,5 +39,3 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 - [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
-
-

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -163,7 +163,7 @@ module SecureHeaders
     # returned is meant to be merged into the header value from `@app.call(env)`
     # in Rack middleware.
     def header_hash_for(request)
-      config = config_for(request, prevent_dup = true)
+      config = config_for(request, _prevent_dup = true)
       headers = config.cached_headers
       user_agent = UserAgent.parse(request.user_agent)
 

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -163,7 +163,8 @@ module SecureHeaders
     # returned is meant to be merged into the header value from `@app.call(env)`
     # in Rack middleware.
     def header_hash_for(request)
-      config = config_for(request, _prevent_dup = true)
+      prevent_dup = true
+      config = config_for(request, prevent_dup)
       headers = config.cached_headers
       user_agent = UserAgent.parse(request.user_agent)
 

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -31,7 +31,7 @@ module SecureHeaders
           raise NotYetConfiguredError, "#{base} policy not yet supplied"
         end
         override = @configurations[base].dup
-        override.instance_eval &block if block_given?
+        override.instance_eval(&block) if block_given?
         add_configuration(name, override)
       end
 
@@ -120,19 +120,36 @@ module SecureHeaders
 
     attr_reader :cached_headers, :csp, :cookies, :csp_report_only, :hpkp, :hpkp_report_host
 
+    @script_hashes = nil
+    @style_hashes = nil
+
     HASH_CONFIG_FILE = ENV["secure_headers_generated_hashes_file"] || "config/secure_headers_generated_hashes.yml"
-    if File.exists?(HASH_CONFIG_FILE)
+    if File.exist?(HASH_CONFIG_FILE)
       config = YAML.safe_load(File.open(HASH_CONFIG_FILE))
       @script_hashes = config["scripts"]
       @style_hashes = config["styles"]
     end
 
     def initialize(&block)
+      @cookies = nil
+      @clear_site_data = nil
+      @csp = nil
+      @csp_report_only = nil
+      @hpkp_report_host = nil
+      @hpkp = nil
+      @hsts = nil
+      @x_content_type_options = nil
+      @x_download_options = nil
+      @x_frame_options = nil
+      @x_permitted_cross_domain_policies = nil
+      @x_xss_protection = nil
+
       self.hpkp = OPT_OUT
       self.referrer_policy = OPT_OUT
       self.csp = ContentSecurityPolicyConfig.new(ContentSecurityPolicyConfig::DEFAULT)
       self.csp_report_only = OPT_OUT
-      instance_eval &block if block_given?
+
+      instance_eval(&block) if block_given?
     end
 
     # Public: copy everything but the cached headers

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -15,6 +15,31 @@ module SecureHeaders
     end
 
     def initialize(hash)
+      @base_uri = nil
+      @block_all_mixed_content = nil
+      @child_src = nil
+      @connect_src = nil
+      @default_src = nil
+      @font_src = nil
+      @form_action = nil
+      @frame_ancestors = nil
+      @frame_src = nil
+      @img_src = nil
+      @manifest_src = nil
+      @media_src = nil
+      @object_src = nil
+      @plugin_types = nil
+      @preserve_schemes = nil
+      @reflected_xss = nil
+      @report_only = nil
+      @report_uri = nil
+      @sandbox = nil
+      @script_nonce = nil
+      @script_src = nil
+      @style_nonce = nil
+      @style_src = nil
+      @upgrade_insecure_requests = nil
+
       from_hash(hash)
       @modified = false
     end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -348,9 +348,9 @@ module SecureHeaders
       end
 
       def ensure_valid_sources!(directive, source_expression)
-        source_expression.each do |source_expression|
-          if ContentSecurityPolicy::DEPRECATED_SOURCE_VALUES.include?(source_expression)
-            raise ContentSecurityPolicyConfigError.new("#{directive} contains an invalid keyword source (#{source_expression}). This value must be single quoted.")
+        source_expression.each do |expression|
+          if ContentSecurityPolicy::DEPRECATED_SOURCE_VALUES.include?(expression)
+            raise ContentSecurityPolicyConfigError.new("#{directive} contains an invalid keyword source (#{expression}). This value must be single quoted.")
           end
         end
       end

--- a/lib/secure_headers/headers/public_key_pins.rb
+++ b/lib/secure_headers/headers/public_key_pins.rb
@@ -49,7 +49,7 @@ module SecureHeaders
     end
 
     def value
-      header_value = [
+      [
         max_age_directive,
         pin_directives,
         report_uri_directive,

--- a/spec/lib/secure_headers/view_helpers_spec.rb
+++ b/spec/lib/secure_headers/view_helpers_spec.rb
@@ -37,7 +37,6 @@ class Message < ERB
     background-color: black;
   }
 </style>
-<%= @name %>
 
 TEMPLATE
   end

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -105,7 +105,7 @@ module SecureHeaders
       end
 
       it "produces a UA-specific CSP when overriding (and busting the cache)" do
-        config = Configuration.default do |config|
+        Configuration.default do |config|
           config.csp = {
             default_src: %w('self'),
             child_src: %w('self')
@@ -231,7 +231,7 @@ module SecureHeaders
 
           SecureHeaders.content_security_policy_script_nonce(request) # should add the value to the header
           hash = SecureHeaders.header_hash_for(chrome_request)
-          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to match /\Adefault-src 'self'; script-src 'self' 'nonce-.*'\z/
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to match(/\Adefault-src 'self'; script-src 'self' 'nonce-.*'\z/)
         end
 
         it "appends a hash to a missing script-src value" do
@@ -243,7 +243,7 @@ module SecureHeaders
 
           SecureHeaders.append_content_security_policy_directives(request, script_src: %w('sha256-abc123'))
           hash = SecureHeaders.header_hash_for(chrome_request)
-          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to match /\Adefault-src 'self'; script-src 'self' 'sha256-abc123'\z/
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to match(/\Adefault-src 'self'; script-src 'self' 'sha256-abc123'\z/)
         end
 
         it "overrides individual directives" do
@@ -279,7 +279,7 @@ module SecureHeaders
           end
 
           safari_request = Rack::Request.new(request.env.merge("HTTP_USER_AGENT" => USER_AGENTS[:safari5]))
-          nonce = SecureHeaders.content_security_policy_script_nonce(safari_request)
+          SecureHeaders.content_security_policy_script_nonce(safari_request)
           hash = SecureHeaders.header_hash_for(safari_request)
           expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; script-src mycdn.com 'unsafe-inline'; style-src 'self'")
         end


### PR DESCRIPTION
I enabled warnings in one of my apps and saw that the secure_headers was the source of a number of warnings. This change enables warnings in rspec and fixes the existing warnings. I ran the test suite about 25-30 times to cover multiple seeds as possible, but there's a chance I still missed some.

## All PRs:

* [x] Has tests
* [x] Documentation updated
