### PR TITLE
Update Clear-Site-Data to use the current spec format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.5
+
+Update clear-site-data header to use current format specified by the specification.
+
 ## 3.6.4
 
 Fix case where mixing frame-src/child-src dynamically would behave in unexpected ways: https://github.com/twitter/secureheaders/pull/325

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The gem will automatically apply several headers that are related to security.  
 - X-Permitted-Cross-Domain-Policies - [Restrict Adobe Flash Player's access to data](https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html)
 - Referrer-Policy - [Referrer Policy draft](https://w3c.github.io/webappsec-referrer-policy/)
 - Public Key Pinning - Pin certificate fingerprints in the browser to prevent man-in-the-middle attacks due to compromised Certificate Authorities. [Public Key Pinning Specification](https://tools.ietf.org/html/rfc7469)
-- Clear-Site-Data - Clearing browser data for origin. [Clear-Site-Data specification](https://www.w3.org/TR/clear-site-data/).
+- Clear-Site-Data - Clearing browser data for origin. [Clear-Site-Data specification](https://w3c.github.io/webappsec-clear-site-data/).
 
 It can also mark all http cookies with the Secure, HttpOnly and SameSite attributes (when configured to do so).
 

--- a/lib/secure_headers/headers/clear_site_data.rb
+++ b/lib/secure_headers/headers/clear_site_data.rb
@@ -2,7 +2,6 @@ module SecureHeaders
   class ClearSiteDataConfigError < StandardError; end
   class ClearSiteData
     HEADER_NAME = "Clear-Site-Data".freeze
-    TYPES = "types".freeze
 
     # Valid `types`
     CACHE = "cache".freeze

--- a/lib/secure_headers/headers/clear_site_data.rb
+++ b/lib/secure_headers/headers/clear_site_data.rb
@@ -40,7 +40,7 @@ module SecureHeaders
         end
       end
 
-      # Public: Transform a Clear-Site-Data config (an Array of String) into a
+      # Public: Transform a Clear-Site-Data config (an Array of Strings) into a
       # String that can be used as the value for the Clear-Site-Data header.
       #
       # types - An Array of String of types of data to clear.

--- a/lib/secure_headers/headers/clear_site_data.rb
+++ b/lib/secure_headers/headers/clear_site_data.rb
@@ -22,9 +22,9 @@ module SecureHeaders
         when nil, OPT_OUT, []
           # noop
         when Array
-          [HEADER_NAME, JSON.dump(TYPES => config)]
+          [HEADER_NAME, make_header_value(config)]
         when true
-          [HEADER_NAME, JSON.dump(TYPES => ALL_TYPES)]
+          [HEADER_NAME, make_header_value(ALL_TYPES)]
         end
       end
 
@@ -36,15 +36,19 @@ module SecureHeaders
           unless config.all? { |t| t.is_a?(String) }
             raise ClearSiteDataConfigError.new("types must be Strings")
           end
-
-          begin
-            JSON.dump(config)
-          rescue JSON::GeneratorError, Encoding::UndefinedConversionError
-            raise ClearSiteDataConfigError.new("types must serializable by JSON")
-          end
         else
           raise ClearSiteDataConfigError.new("config must be an Array of Strings or `true`")
         end
+      end
+
+      # Public: Transform a Clear-Site-Data config (an Array of String) into a
+      # String that can be used as the value for the Clear-Site-Data header.
+      #
+      # types - An Array of String of types of data to clear.
+      #
+      # Returns a String of quoted values that are comma separated.
+      def make_header_value(types)
+        types.map { |t| "\"#{t}\""}.join(", ")
       end
     end
   end

--- a/secure_headers.gemspec
+++ b/secure_headers.gemspec
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |gem|
   gem.name          = "secure_headers"
-  gem.version       = "3.6.4"
+  gem.version       = "3.6.5"
   gem.authors       = ["Neil Matatall"]
   gem.email         = ["neil.matatall@gmail.com"]
   gem.description   = 'Manages application of security headers with many safe defaults.'

--- a/spec/lib/secure_headers/headers/clear_site_data_spec.rb
+++ b/spec/lib/secure_headers/headers/clear_site_data_spec.rb
@@ -20,7 +20,7 @@ module SecureHeaders
 
         expect(name).to eq(ClearSiteData::HEADER_NAME)
         expect(value).to eq(
-          ClearSiteData.make_header_value(ClearSiteData::ALL_TYPES)
+          %("cache", "cookies", "storage", "executionContexts")
         )
       end
 
@@ -28,7 +28,7 @@ module SecureHeaders
         name, value = described_class.make_header(["foo", "bar"])
 
         expect(name).to eq(ClearSiteData::HEADER_NAME)
-        expect(value).to eq(ClearSiteData.make_header_value(["foo", "bar"]))
+        expect(value).to eq(%("foo", "bar"))
       end
     end
 
@@ -77,10 +77,10 @@ module SecureHeaders
     end
 
     describe "make_header_value" do
-        it "returns a string of quoted values that are comma separated" do
-          value = described_class.make_header_value(["foo", "bar"])
-          expect(value).to eq(%("foo", "bar"))
-        end
+      it "returns a string of quoted values that are comma separated" do
+        value = described_class.make_header_value(["foo", "bar"])
+        expect(value).to eq(%("foo", "bar"))
+      end
     end
   end
 end

--- a/spec/lib/secure_headers/headers/clear_site_data_spec.rb
+++ b/spec/lib/secure_headers/headers/clear_site_data_spec.rb
@@ -19,30 +19,16 @@ module SecureHeaders
         name, value = described_class.make_header(true)
 
         expect(name).to eq(ClearSiteData::HEADER_NAME)
-        expect(value).to eq(normalize_json(<<-HERE))
-          {
-            "types": [
-              "cache",
-              "cookies",
-              "storage",
-              "executionContexts"
-            ]
-          }
-        HERE
+        expect(value).to eq(
+          ClearSiteData.make_header_value(ClearSiteData::ALL_TYPES)
+        )
       end
 
       it "returns specified types" do
         name, value = described_class.make_header(["foo", "bar"])
 
         expect(name).to eq(ClearSiteData::HEADER_NAME)
-        expect(value).to eq(normalize_json(<<-HERE))
-          {
-            "types": [
-              "foo",
-              "bar"
-            ]
-          }
-        HERE
+        expect(value).to eq(ClearSiteData.make_header_value(["foo", "bar"]))
       end
     end
 
@@ -83,12 +69,6 @@ module SecureHeaders
         end.to raise_error(ClearSiteDataConfigError)
       end
 
-      it "fails for non-serializable config" do
-        expect do
-          described_class.validate_config!(["hi \255"])
-        end.to raise_error(ClearSiteDataConfigError)
-      end
-
       it "fails for other types of config" do
         expect do
           described_class.validate_config!(:cookies)
@@ -96,8 +76,11 @@ module SecureHeaders
       end
     end
 
-    def normalize_json(json)
-      JSON.dump(JSON.parse(json))
+    describe "make_header_value" do
+        it "returns a string of quoted values that are comma separated" do
+          value = described_class.make_header_value(["foo", "bar"])
+          expect(value).to eq(%("foo", "bar"))
+        end
     end
   end
 end


### PR DESCRIPTION
Per request from @mikewest [via twitter](https://twitter.com/mikewest/status/877149667909406723), this PR updates the format used in the `Clear-Site-Data` header to the current format. 

/cc @oreoshake for review