### PR TITLE
Fixes #336  Pins dependency version of useragent

### DIFF
--- a/secure_headers.gemspec
+++ b/secure_headers.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
   gem.add_development_dependency "rake"
-  gem.add_dependency "useragent"
+  gem.add_dependency "useragent", ">= 0.15.0"
 end


### PR DESCRIPTION
As per #336, secure_headers actually **_needs_** a minimum version of useragent. `v0.15.0` is the earliest version in which all the tests pass. Before `v0.9.0` secure_headers is not useable at all. 

Please view #336 for full discussion. 