### PR TITLE
[4.x prep] Require a script-src, change default CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.x
+
+- `script_src` is required to be set in CSP configs. Falling back to *any* `default-src` can be bad. It's certainly possible for this to not cause a problem but better safe than sorry.
+- The default CSP has been changed: `default-src 'self', form-action 'self'; object-src 'none'; script-src https:; style-src 'self' 'unsafe-inline' https:` This policy is "more secure" and more reasonable.
+
 ## 3.6.5
 
 Update clear-site-data header to use current format specified by the specification.

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,6 @@ end
 
 group :guard do
   gem "growl"
-  gem "guard-rspec", platforms: [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
+  gem "guard-rspec", platforms: [:ruby_19, :ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem "rb-fsevent"
 end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -7,7 +7,13 @@ module SecureHeaders
 
     MODERN_BROWSERS = %w(Chrome Opera Firefox)
     DEFAULT_VALUE = "default-src https:".freeze
-    DEFAULT_CONFIG = { default_src: %w(https:) }.freeze
+    DEFAULT_CONFIG = {
+      default_src: %w(https:),
+      object_src: %w('none'),
+      script_src: %w(https:),
+      style_src: %w('self' 'unsafe-inline' https:),
+      form_action: %w('self')
+    }.freeze
     DATA_PROTOCOL = "data:".freeze
     BLOB_PROTOCOL = "blob:".freeze
     SELF = "'self'".freeze

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -9,6 +9,7 @@ module SecureHeaders
     DEFAULT_VALUE = "default-src https:".freeze
     DEFAULT_CONFIG = {
       default_src: %w(https:),
+      img_src: %w(https: data: 'self'),
       object_src: %w('none'),
       script_src: %w(https:),
       style_src: %w('self' 'unsafe-inline' https:),

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -210,7 +210,7 @@ module SecureHeaders
       def validate_config!(config)
         return if config.nil? || config.opt_out?
         raise ContentSecurityPolicyConfigError.new(":default_src is required") unless config.directive_value(:default_src)
-        raise ContentSecurityPolicyConfigError.new(":script is required, falling back to default-src is too dangerous") unless config.directive_value(:script_src)
+        raise ContentSecurityPolicyConfigError.new(":script_src is required, falling back to default-src is too dangerous") unless config.directive_value(:script_src)
         ContentSecurityPolicyConfig.attrs.each do |key|
           value = config.directive_value(key)
           next unless value

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -210,6 +210,7 @@ module SecureHeaders
       def validate_config!(config)
         return if config.nil? || config.opt_out?
         raise ContentSecurityPolicyConfigError.new(":default_src is required") unless config.directive_value(:default_src)
+        raise ContentSecurityPolicyConfigError.new(":script is required, falling back to default-src is too dangerous") unless config.directive_value(:script_src)
         ContentSecurityPolicyConfig.attrs.each do |key|
           value = config.directive_value(key)
           next unless value

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -71,7 +71,7 @@ module SecureHeaders
 
     it "allows you to override an override" do
       Configuration.override(:override) do |config|
-        config.csp = { default_src: %w('self')}
+        config.csp = { default_src: %w('self'), script_src: %w('self')}
       end
 
       Configuration.override(:second_override, :override) do |config|
@@ -79,7 +79,7 @@ module SecureHeaders
       end
 
       original_override = Configuration.get(:override)
-      expect(original_override.csp.to_h).to eq(default_src: %w('self'))
+      expect(original_override.csp.to_h).to eq(default_src: %w('self'), script_src: %w('self'))
       override_config = Configuration.get(:second_override)
       expect(override_config.csp.to_h).to eq(default_src: %w('self'), script_src: %w('self' example.org))
     end

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -24,6 +24,10 @@ module SecureHeaders
     end
 
     describe "#value" do
+      it "uses a safe but non-breaking default value" do
+        expect(ContentSecurityPolicy.new.value).to eq("default-src https:; form-action 'self'; object-src 'none'; script-src https:; style-src 'self' 'unsafe-inline' https:")
+      end
+
       it "discards 'none' values if any other source expressions are present" do
         csp = ContentSecurityPolicy.new(default_opts.merge(child_src: %w('self' 'none')))
         expect(csp.value).not_to include("'none'")

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -25,7 +25,7 @@ module SecureHeaders
 
     describe "#value" do
       it "uses a safe but non-breaking default value" do
-        expect(ContentSecurityPolicy.new.value).to eq("default-src https:; form-action 'self'; object-src 'none'; script-src https:; style-src 'self' 'unsafe-inline' https:")
+        expect(ContentSecurityPolicy.new.value).to eq("default-src https:; form-action 'self'; img-src https: data: 'self'; object-src 'none'; script-src https:; style-src 'self' 'unsafe-inline' https:")
       end
 
       it "discards 'none' values if any other source expressions are present" do

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -31,7 +31,7 @@ module SecureHeaders
     describe "#header_hash_for" do
       it "allows you to opt out of individual headers via API" do
         Configuration.default do |config|
-          config.csp = { default_src: %w('self')}
+          config.csp = { default_src: %w('self'), script_src: %w('self')}
           config.csp_report_only = config.csp
         end
         SecureHeaders.opt_out_of_header(request, ContentSecurityPolicyConfig::CONFIG_KEY)
@@ -63,7 +63,7 @@ module SecureHeaders
       it "allows you to opt out entirely" do
         # configure the disabled-by-default headers to ensure they also do not get set
         Configuration.default do |config|
-          config.csp = { default_src: ["example.com"] }
+          config.csp = { default_src: ["example.com"], script_src: %w('self') }
           config.csp_report_only = config.csp
           config.hpkp = {
             report_only: false,
@@ -109,6 +109,7 @@ module SecureHeaders
         Configuration.default do |config|
           config.csp = {
             default_src: %w('self'),
+            script_src: %w('self'),
             child_src: %w('self')
           }
         end
@@ -178,38 +179,41 @@ module SecureHeaders
           Configuration.default do |config|
             config.csp = {
               default_src: %w('self'),
-              frame_src: %w(frame_src.com)
+              frame_src: %w(frame_src.com),
+              script_src: %w('self')
             }
           end
 
           SecureHeaders.append_content_security_policy_directives(chrome_request, child_src: %w(child_src.com))
           hash = SecureHeaders.header_hash_for(chrome_request)
-          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; child-src frame_src.com child_src.com")
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; child-src frame_src.com child_src.com; script-src 'self'")
         end
 
         it "appends frame-src to child-src" do
           Configuration.default do |config|
             config.csp = {
               default_src: %w('self'),
-              child_src: %w(child_src.com)
+              child_src: %w(child_src.com),
+              script_src: %w('self')
             }
           end
 
           safari_request = Rack::Request.new(request.env.merge("HTTP_USER_AGENT" => USER_AGENTS[:safari6]))
           SecureHeaders.append_content_security_policy_directives(safari_request, frame_src: %w(frame_src.com))
           hash = SecureHeaders.header_hash_for(safari_request)
-          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; frame-src child_src.com frame_src.com")
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self'; frame-src child_src.com frame_src.com; script-src 'self'")
         end
 
         it "supports named appends" do
           Configuration.default do |config|
             config.csp = {
-              default_src: %w('self')
+              default_src: %w('self'),
+              script_src: %w('self')
             }
           end
 
           Configuration.named_append(:moar_default_sources) do |request|
-            { default_src: %w(https:)}
+            { default_src: %w(https:), style_src: %w('self')}
           end
 
           Configuration.named_append(:how_about_a_script_src_too) do |request|
@@ -220,13 +224,14 @@ module SecureHeaders
           SecureHeaders.use_content_security_policy_named_append(request, :how_about_a_script_src_too)
           hash = SecureHeaders.header_hash_for(request)
 
-          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self' https:; script-src 'self' https: 'unsafe-inline'")
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self' https:; script-src 'self' 'unsafe-inline'; style-src 'self'")
         end
 
         it "appends a nonce to a missing script-src value" do
           Configuration.default do |config|
             config.csp = {
-              default_src: %w('self')
+              default_src: %w('self'),
+              script_src: %w('self')
             }
           end
 
@@ -238,7 +243,8 @@ module SecureHeaders
         it "appends a hash to a missing script-src value" do
           Configuration.default do |config|
             config.csp = {
-              default_src: %w('self')
+              default_src: %w('self'),
+              script_src: %w('self')
             }
           end
 
@@ -250,24 +256,26 @@ module SecureHeaders
         it "overrides individual directives" do
           Configuration.default do |config|
             config.csp = {
-              default_src: %w('self')
+              default_src: %w('self'),
+              script_src: %w('self')
             }
           end
           SecureHeaders.override_content_security_policy_directives(request, default_src: %w('none'))
           hash = SecureHeaders.header_hash_for(request)
-          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'none'")
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'none'; script-src 'self'")
         end
 
         it "overrides non-existant directives" do
           Configuration.default do |config|
             config.csp = {
-              default_src: %w(https:)
+              default_src: %w(https:),
+              script_src: %w('self')
             }
           end
           SecureHeaders.override_content_security_policy_directives(request, img_src: [ContentSecurityPolicy::DATA_PROTOCOL])
           hash = SecureHeaders.header_hash_for(request)
           expect(hash[ContentSecurityPolicyReportOnlyConfig::HEADER_NAME]).to be_nil
-          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src https:; img-src data:")
+          expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src https:; img-src data:; script-src 'self'")
         end
 
         it "does not append a nonce when the browser does not support it" do
@@ -325,6 +333,7 @@ module SecureHeaders
           Configuration.default do |config|
             config.csp = {
               default_src: %w('self'),
+              script_src: %w('self'),
               report_only: true
             }
           end
@@ -334,7 +343,7 @@ module SecureHeaders
 
           hash = SecureHeaders.header_hash_for(request)
           expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to be_nil
-          expect(hash[ContentSecurityPolicyReportOnlyConfig::HEADER_NAME]).to eq("default-src 'self'")
+          expect(hash[ContentSecurityPolicyReportOnlyConfig::HEADER_NAME]).to eq("default-src 'self'; script-src 'self'")
         end
 
         it "Raises an error if csp_report_only is used with `report_only: false`" do
@@ -342,6 +351,7 @@ module SecureHeaders
             Configuration.default do |config|
               config.csp_report_only = {
                 default_src: %w('self'),
+                script_src: %w('self'),
                 report_only: false
               }
             end
@@ -352,7 +362,8 @@ module SecureHeaders
           before(:each) do
             Configuration.default do |config|
               config.csp = {
-                default_src: %w('self')
+                default_src: %w('self'),
+                script_src: %w('self')
               }
               config.csp_report_only = config.csp
             end
@@ -361,82 +372,88 @@ module SecureHeaders
           it "sets identical values when the configs are the same" do
             Configuration.default do |config|
               config.csp = {
-                default_src: %w('self')
+                default_src: %w('self'),
+                script_src: %w('self')
               }
               config.csp_report_only = {
-                default_src: %w('self')
+                default_src: %w('self'),
+                script_src: %w('self')
               }
             end
 
             hash = SecureHeaders.header_hash_for(request)
-            expect(hash["Content-Security-Policy"]).to eq("default-src 'self'")
-            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'")
+            expect(hash["Content-Security-Policy"]).to eq("default-src 'self'; script-src 'self'")
+            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src 'self'")
           end
 
           it "sets different headers when the configs are different" do
             Configuration.default do |config|
               config.csp = {
-                default_src: %w('self')
+                default_src: %w('self'),
+                script_src: %w('self')
               }
-              config.csp_report_only = config.csp.merge({script_src: %w('self')})
+              config.csp_report_only = config.csp.merge({script_src: %w(foo.com)})
             end
 
             hash = SecureHeaders.header_hash_for(request)
-            expect(hash["Content-Security-Policy"]).to eq("default-src 'self'")
-            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src 'self'")
+            expect(hash["Content-Security-Policy"]).to eq("default-src 'self'; script-src 'self'")
+            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src 'self' foo.com")
           end
 
           it "allows you to opt-out of enforced CSP" do
             Configuration.default do |config|
               config.csp = SecureHeaders::OPT_OUT
               config.csp_report_only = {
-                default_src: %w('self')
+                default_src: %w('self'),
+                script_src: %w('self')
               }
             end
 
             hash = SecureHeaders.header_hash_for(request)
             expect(hash["Content-Security-Policy"]).to be_nil
-            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'")
+            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src 'self'")
           end
 
           it "opts-out of enforced CSP when only csp_report_only is set" do
             expect(Kernel).to receive(:warn).once
             Configuration.default do |config|
               config.csp_report_only = {
-                default_src: %w('self')
+                default_src: %w('self'),
+                script_src: %w('self')
               }
             end
 
             hash = SecureHeaders.header_hash_for(request)
             expect(hash["Content-Security-Policy"]).to be_nil
-            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'")
+            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src 'self'")
           end
 
           it "allows you to set csp_report_only before csp" do
             expect(Kernel).to receive(:warn).once
             Configuration.default do |config|
               config.csp_report_only = {
-                default_src: %w('self')
+                default_src: %w('self'),
+                script_src: %w('self')
               }
               config.csp = config.csp_report_only.merge({script_src: %w('unsafe-inline')})
             end
 
             hash = SecureHeaders.header_hash_for(request)
             expect(hash["Content-Security-Policy"]).to eq("default-src 'self'; script-src 'self' 'unsafe-inline'")
-            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'")
+            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src 'self'")
           end
 
           it "allows appending to the enforced policy" do
             SecureHeaders.append_content_security_policy_directives(request, {script_src: %w(anothercdn.com)}, :enforced)
             hash = SecureHeaders.header_hash_for(request)
             expect(hash["Content-Security-Policy"]).to eq("default-src 'self'; script-src 'self' anothercdn.com")
-            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'")
+            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src 'self'")
           end
 
           it "allows appending to the report only policy" do
             SecureHeaders.append_content_security_policy_directives(request, {script_src: %w(anothercdn.com)}, :report_only)
             hash = SecureHeaders.header_hash_for(request)
-            expect(hash["Content-Security-Policy"]).to eq("default-src 'self'")
+            expect(hash["Content-Security-Policy"]).to eq("default-src 'self'; script-src 'self'")
             expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src 'self' anothercdn.com")
           end
 
@@ -451,13 +468,13 @@ module SecureHeaders
             SecureHeaders.override_content_security_policy_directives(request, {script_src: %w(anothercdn.com)}, :enforced)
             hash = SecureHeaders.header_hash_for(request)
             expect(hash["Content-Security-Policy"]).to eq("default-src 'self'; script-src anothercdn.com")
-            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'")
+            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src 'self'")
           end
 
           it "allows overriding the report only policy" do
             SecureHeaders.override_content_security_policy_directives(request, {script_src: %w(anothercdn.com)}, :report_only)
             hash = SecureHeaders.header_hash_for(request)
-            expect(hash["Content-Security-Policy"]).to eq("default-src 'self'")
+            expect(hash["Content-Security-Policy"]).to eq("default-src 'self'; script-src 'self'")
             expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src anothercdn.com")
           end
 
@@ -472,7 +489,8 @@ module SecureHeaders
             it "updates the enforced header when configured" do
               Configuration.default do |config|
                 config.csp = {
-                  default_src: %w('self')
+                  default_src: %w('self'),
+                  script_src: %w('self')
                 }
               end
               SecureHeaders.append_content_security_policy_directives(request, {script_src: %w(anothercdn.com)})
@@ -486,7 +504,8 @@ module SecureHeaders
               Configuration.default do |config|
                 config.csp = OPT_OUT
                 config.csp_report_only = {
-                  default_src: %w('self')
+                  default_src: %w('self'),
+                  script_src: %w('self')
                 }
               end
               SecureHeaders.append_content_security_policy_directives(request, {script_src: %w(anothercdn.com)})
@@ -499,17 +518,19 @@ module SecureHeaders
             it "updates both headers if both are configured" do
               Configuration.default do |config|
                 config.csp = {
-                  default_src: %w(enforced.com)
+                  default_src: %w(enforced.com),
+                  script_src: %w('self')
                 }
                 config.csp_report_only = {
-                  default_src: %w(reportonly.com)
+                  default_src: %w(reportonly.com),
+                  script_src: %w('self')
                 }
               end
               SecureHeaders.append_content_security_policy_directives(request, {script_src: %w(anothercdn.com)})
 
               hash = SecureHeaders.header_hash_for(request)
-              expect(hash["Content-Security-Policy"]).to eq("default-src enforced.com; script-src enforced.com anothercdn.com")
-              expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src reportonly.com; script-src reportonly.com anothercdn.com")
+              expect(hash["Content-Security-Policy"]).to eq("default-src enforced.com; script-src 'self' anothercdn.com")
+              expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src reportonly.com; script-src 'self' anothercdn.com")
             end
 
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,6 @@
 require "rubygems"
 require "rspec"
 require "rack"
-require "pry-nav"
-
 require "coveralls"
 Coveralls.wear!
 


### PR DESCRIPTION
This handles the first two items from https://github.com/twitter/secureheaders/issues/286

> - Require `script-src` to be set. Missing `script-src`s inherit from `default-src`. In general `default-src` lists are far too permissive for something like `script-src`.
> - Require `object-src` to be set. See ⬆️ 

/cc @stve @jacobbednarz

CI isn't green yet, but it works on my machine