### PR TITLE
Adds secure, httponly, and SameSite=lax to cookies by default

### DIFF
--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -4,6 +4,17 @@ SecureHeaders supports `Secure`, `HttpOnly` and [`SameSite`](https://tools.ietf.
 
 __Note__: Regardless of the configuration specified, Secure cookies are only enabled for HTTPS requests.
 
+#### Defaults
+
+By default, all cookies will get both `Secure` and `HttpOnly`.
+
+```ruby
+config.cookies = {
+  secure: true, # defaults to true but will be a no op on non-HTTPS requests
+  httponly: true, # defaults to true
+}
+```
+
 #### Boolean-based configuration
 
 Boolean-based configuration is intended to globally enable or disable a specific cookie attribute.

--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -6,7 +6,7 @@ __Note__: Regardless of the configuration specified, Secure cookies are only ena
 
 #### Defaults
 
-By default, all cookies will get both `Secure` and `HttpOnly`.
+By default, all cookies will get both `Secure`, `HttpOnly`, and `SameSite=Lax`.
 
 ```ruby
 config.cookies = {

--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -12,17 +12,20 @@ By default, all cookies will get both `Secure` and `HttpOnly`.
 config.cookies = {
   secure: true, # defaults to true but will be a no op on non-HTTPS requests
   httponly: true, # defaults to true
+  samesite: {  # defaults to set `SameSite=Lax`
+    lax: true
+  }
 }
 ```
 
 #### Boolean-based configuration
 
-Boolean-based configuration is intended to globally enable or disable a specific cookie attribute.
+Boolean-based configuration is intended to globally enable or disable a specific cookie attribute. *Note: As of 4.0, you must use OPT_OUT rather than false to opt out of the defaults.*
 
 ```ruby
 config.cookies = {
   secure: true, # mark all cookies as Secure
-  httponly: false, # do not mark any cookies as HttpOnly
+  httponly: OPT_OUT, # do not mark any cookies as HttpOnly
 }
 ```
 

--- a/lib/secure_headers/headers/cookie.rb
+++ b/lib/secure_headers/headers/cookie.rb
@@ -2,6 +2,7 @@
 require "cgi"
 require "secure_headers/utils/cookies_config"
 
+
 module SecureHeaders
   class CookiesConfigError < StandardError; end
   class Cookie
@@ -14,12 +15,16 @@ module SecureHeaders
 
     attr_reader :raw_cookie, :config
 
+    COOKIE_DEFAULTS = {
+      httponly: true,
+      secure: true,
+    }.freeze
+
     def initialize(cookie, config)
       @raw_cookie = cookie
       unless config == SecureHeaders::OPT_OUT
         config ||= {}
-        config[:secure] = true if config[:secure].nil?
-        config[:httponly] = true if config[:httponly].nil?
+        config = COOKIE_DEFAULTS.merge(config)
       end
       @config = config
       @attributes = {

--- a/lib/secure_headers/headers/cookie.rb
+++ b/lib/secure_headers/headers/cookie.rb
@@ -98,7 +98,7 @@ module SecureHeaders
     end
 
     def flag_samesite?
-      return false if config == OPT_OUT or config[:samesite] == OPT_OUT
+      return false if config == OPT_OUT || config[:samesite] == OPT_OUT
       flag_samesite_lax? || flag_samesite_strict?
     end
 

--- a/lib/secure_headers/headers/cookie.rb
+++ b/lib/secure_headers/headers/cookie.rb
@@ -16,6 +16,11 @@ module SecureHeaders
 
     def initialize(cookie, config)
       @raw_cookie = cookie
+      unless config == SecureHeaders::OPT_OUT
+        config ||= {}
+        config[:secure] = true if config[:secure].nil?
+        config[:httponly] = true if config[:httponly].nil?
+      end
       @config = config
       @attributes = {
         httponly: nil,
@@ -57,6 +62,7 @@ module SecureHeaders
     end
 
     def flag_cookie?(attribute)
+      return false if config == SecureHeaders::OPT_OUT
       case config[attribute]
       when TrueClass
         true
@@ -86,6 +92,7 @@ module SecureHeaders
     end
 
     def flag_samesite?
+      return false if config == SecureHeaders::OPT_OUT
       flag_samesite_lax? || flag_samesite_strict?
     end
 

--- a/lib/secure_headers/headers/cookie.rb
+++ b/lib/secure_headers/headers/cookie.rb
@@ -18,11 +18,12 @@ module SecureHeaders
     COOKIE_DEFAULTS = {
       httponly: true,
       secure: true,
+      samesite: { lax: true },
     }.freeze
 
     def initialize(cookie, config)
       @raw_cookie = cookie
-      unless config == SecureHeaders::OPT_OUT
+      unless config == OPT_OUT
         config ||= {}
         config = COOKIE_DEFAULTS.merge(config)
       end
@@ -67,7 +68,7 @@ module SecureHeaders
     end
 
     def flag_cookie?(attribute)
-      return false if config == SecureHeaders::OPT_OUT
+      return false if config == OPT_OUT
       case config[attribute]
       when TrueClass
         true
@@ -97,7 +98,7 @@ module SecureHeaders
     end
 
     def flag_samesite?
-      return false if config == SecureHeaders::OPT_OUT
+      return false if config == OPT_OUT or config[:samesite] == OPT_OUT
       flag_samesite_lax? || flag_samesite_strict?
     end
 

--- a/lib/secure_headers/middleware.rb
+++ b/lib/secure_headers/middleware.rb
@@ -39,7 +39,7 @@ module SecureHeaders
     # disable Secure cookies for non-https requests
     def override_secure(env, config = {})
       if scheme(env) != "https"
-        config[:secure] = false
+        config[:secure] = OPT_OUT
       end
 
       config

--- a/lib/secure_headers/utils/cookies_config.rb
+++ b/lib/secure_headers/utils/cookies_config.rb
@@ -12,9 +12,9 @@ module SecureHeaders
       return if config.nil? || config == SecureHeaders::OPT_OUT
 
       validate_config!
-      validate_secure_config! if config[:secure]
-      validate_httponly_config! if config[:httponly]
-      validate_samesite_config! if config[:samesite]
+      validate_secure_config! unless config[:secure].nil?
+      validate_httponly_config! unless config[:httponly].nil?
+      validate_samesite_config! unless config[:samesite].nil?
     end
 
     private
@@ -24,12 +24,12 @@ module SecureHeaders
     end
 
     def validate_secure_config!
-      validate_hash_or_boolean!(:secure)
+      validate_hash_or_true_or_opt_out!(:secure)
       validate_exclusive_use_of_hash_constraints!(config[:secure], :secure)
     end
 
     def validate_httponly_config!
-      validate_hash_or_boolean!(:httponly)
+      validate_hash_or_true_or_opt_out!(:httponly)
       validate_exclusive_use_of_hash_constraints!(config[:httponly], :httponly)
     end
 
@@ -62,8 +62,8 @@ module SecureHeaders
       end
     end
 
-    def validate_hash_or_boolean!(attribute)
-      if !(is_hash?(config[attribute]) || is_boolean?(config[attribute]))
+    def validate_hash_or_true_or_opt_out!(attribute)
+      if !(is_hash?(config[attribute]) || is_true_or_opt_out?(config[attribute]))
         raise CookiesConfigError.new("#{attribute} cookie config must be a hash or boolean")
       end
     end
@@ -71,7 +71,6 @@ module SecureHeaders
     # validate exclusive use of only or except but not both at the same time
     def validate_exclusive_use_of_hash_constraints!(conf, attribute)
       return unless is_hash?(conf)
-
       if conf.key?(:only) && conf.key?(:except)
         raise CookiesConfigError.new("#{attribute} cookie config is invalid, simultaneous use of conditional arguments `only` and `except` is not permitted.")
       end
@@ -88,8 +87,8 @@ module SecureHeaders
       obj && obj.is_a?(Hash)
     end
 
-    def is_boolean?(obj)
-      obj && (obj.is_a?(TrueClass) || obj.is_a?(FalseClass))
+    def is_true_or_opt_out?(obj)
+      obj && (obj.is_a?(TrueClass) || obj == OPT_OUT)
     end
   end
 end

--- a/lib/secure_headers/utils/cookies_config.rb
+++ b/lib/secure_headers/utils/cookies_config.rb
@@ -34,6 +34,7 @@ module SecureHeaders
     end
 
     def validate_samesite_config!
+      return if config[:samesite] == OPT_OUT
       raise CookiesConfigError.new("samesite cookie config must be a hash") unless is_hash?(config[:samesite])
 
       validate_samesite_boolean_config!

--- a/spec/lib/secure_headers/headers/cookie_spec.rb
+++ b/spec/lib/secure_headers/headers/cookie_spec.rb
@@ -16,12 +16,12 @@ module SecureHeaders
     end
 
     it "preserves existing attributes" do
-      cookie = Cookie.new("_session=thisisatest; secure", {secure: true, httponly: false})
+      cookie = Cookie.new("_session=thisisatest; secure", secure: true, httponly: false)
       expect(cookie.to_s).to eq("_session=thisisatest; secure")
     end
 
     it "prevents duplicate flagging of attributes" do
-      cookie = Cookie.new("_session=thisisatest; secure", {secure: true, httponly: false})
+      cookie = Cookie.new("_session=thisisatest; secure", secure: true, httponly: false)
       expect(cookie.to_s.scan(/secure/i).count).to eq(1)
     end
 
@@ -35,12 +35,12 @@ module SecureHeaders
 
       context "when configured with a Hash" do
         it "flags cookies as Secure when whitelisted" do
-          cookie = Cookie.new(raw_cookie, {secure: { only: ["_session"]}, httponly: false})
+          cookie = Cookie.new(raw_cookie, secure: { only: ["_session"]}, httponly: false)
           expect(cookie.to_s).to eq("_session=thisisatest; secure")
         end
 
         it "does not flag cookies as Secure when excluded" do
-          cookie = Cookie.new(raw_cookie, {secure: { except: ["_session"] }, httponly: false})
+          cookie = Cookie.new(raw_cookie, secure: { except: ["_session"] }, httponly: false)
           expect(cookie.to_s).to eq("_session=thisisatest")
         end
       end
@@ -100,13 +100,13 @@ module SecureHeaders
 
       it "flags properly when both lax and strict are configured" do
         raw_cookie = "_session=thisisatest"
-        cookie = Cookie.new(raw_cookie, {samesite: { strict: { only: ["_session"] }, lax: { only: ["_additional_session"] } }, secure: false, httponly: false})
+        cookie = Cookie.new(raw_cookie, samesite: { strict: { only: ["_session"] }, lax: { only: ["_additional_session"] } }, secure: false, httponly: false)
         expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Strict")
       end
 
       it "ignores configuration if the cookie is already flagged" do
         raw_cookie = "_session=thisisatest; SameSite=Strict"
-        cookie = Cookie.new(raw_cookie, {samesite: { lax: true }, secure: false, httponly: false})
+        cookie = Cookie.new(raw_cookie, samesite: { lax: true }, secure: false, httponly: false)
         expect(cookie.to_s).to eq(raw_cookie)
       end
     end

--- a/spec/lib/secure_headers/headers/cookie_spec.rb
+++ b/spec/lib/secure_headers/headers/cookie_spec.rb
@@ -16,31 +16,31 @@ module SecureHeaders
     end
 
     it "preserves existing attributes" do
-      cookie = Cookie.new("_session=thisisatest; secure", secure: true, httponly: false)
+      cookie = Cookie.new("_session=thisisatest; secure", secure: true, httponly: OPT_OUT)
       expect(cookie.to_s).to eq("_session=thisisatest; secure")
     end
 
     it "prevents duplicate flagging of attributes" do
-      cookie = Cookie.new("_session=thisisatest; secure", secure: true, httponly: false)
+      cookie = Cookie.new("_session=thisisatest; secure", secure: true, httponly: OPT_OUT)
       expect(cookie.to_s.scan(/secure/i).count).to eq(1)
     end
 
     context "Secure cookies" do
       context "when configured with a boolean" do
         it "flags cookies as Secure" do
-          cookie = Cookie.new(raw_cookie, secure: true, httponly: false)
+          cookie = Cookie.new(raw_cookie, secure: true, httponly: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest; secure")
         end
       end
 
       context "when configured with a Hash" do
         it "flags cookies as Secure when whitelisted" do
-          cookie = Cookie.new(raw_cookie, secure: { only: ["_session"]}, httponly: false)
+          cookie = Cookie.new(raw_cookie, secure: { only: ["_session"]}, httponly: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest; secure")
         end
 
         it "does not flag cookies as Secure when excluded" do
-          cookie = Cookie.new(raw_cookie, secure: { except: ["_session"] }, httponly: false)
+          cookie = Cookie.new(raw_cookie, secure: { except: ["_session"] }, httponly: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest")
         end
       end
@@ -49,19 +49,19 @@ module SecureHeaders
     context "HttpOnly cookies" do
       context "when configured with a boolean" do
         it "flags cookies as HttpOnly" do
-          cookie = Cookie.new(raw_cookie, httponly: true, secure: false)
+          cookie = Cookie.new(raw_cookie, httponly: true, secure: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest; HttpOnly")
         end
       end
 
       context "when configured with a Hash" do
         it "flags cookies as HttpOnly when whitelisted" do
-          cookie = Cookie.new(raw_cookie, httponly: { only: ["_session"]}, secure: false)
+          cookie = Cookie.new(raw_cookie, httponly: { only: ["_session"]}, secure: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest; HttpOnly")
         end
 
         it "does not flag cookies as HttpOnly when excluded" do
-          cookie = Cookie.new(raw_cookie, httponly: { except: ["_session"] }, secure: false)
+          cookie = Cookie.new(raw_cookie, httponly: { except: ["_session"] }, secure: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest")
         end
       end
@@ -69,44 +69,44 @@ module SecureHeaders
 
     context "SameSite cookies" do
       it "flags SameSite=Lax" do
-        cookie = Cookie.new(raw_cookie, samesite: { lax: { only: ["_session"] } }, secure: false, httponly: false)
+        cookie = Cookie.new(raw_cookie, samesite: { lax: { only: ["_session"] } }, secure: OPT_OUT, httponly: OPT_OUT)
         expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Lax")
       end
 
       it "flags SameSite=Lax when configured with a boolean" do
-        cookie = Cookie.new(raw_cookie, samesite: { lax: true}, secure: false, httponly: false)
+        cookie = Cookie.new(raw_cookie, samesite: { lax: true}, secure: OPT_OUT, httponly: OPT_OUT)
         expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Lax")
       end
 
       it "does not flag cookies as SameSite=Lax when excluded" do
-        cookie = Cookie.new(raw_cookie, samesite: { lax: { except: ["_session"] } }, secure: false, httponly: false)
+        cookie = Cookie.new(raw_cookie, samesite: { lax: { except: ["_session"] } }, secure: OPT_OUT, httponly: OPT_OUT)
         expect(cookie.to_s).to eq("_session=thisisatest")
       end
 
       it "flags SameSite=Strict" do
-        cookie = Cookie.new(raw_cookie, samesite: { strict: { only: ["_session"] } }, secure: false, httponly: false)
+        cookie = Cookie.new(raw_cookie, samesite: { strict: { only: ["_session"] } }, secure: OPT_OUT, httponly: OPT_OUT)
         expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Strict")
       end
 
       it "does not flag cookies as SameSite=Strict when excluded" do
-        cookie = Cookie.new(raw_cookie, samesite: { strict: { except: ["_session"] }}, secure: false, httponly: false)
+        cookie = Cookie.new(raw_cookie, samesite: { strict: { except: ["_session"] }}, secure: OPT_OUT, httponly: OPT_OUT)
         expect(cookie.to_s).to eq("_session=thisisatest")
       end
 
       it "flags SameSite=Strict when configured with a boolean" do
-        cookie = Cookie.new(raw_cookie, {samesite: { strict: true}, secure: false, httponly: false})
+        cookie = Cookie.new(raw_cookie, {samesite: { strict: true}, secure: OPT_OUT, httponly: OPT_OUT})
         expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Strict")
       end
 
       it "flags properly when both lax and strict are configured" do
         raw_cookie = "_session=thisisatest"
-        cookie = Cookie.new(raw_cookie, samesite: { strict: { only: ["_session"] }, lax: { only: ["_additional_session"] } }, secure: false, httponly: false)
+        cookie = Cookie.new(raw_cookie, samesite: { strict: { only: ["_session"] }, lax: { only: ["_additional_session"] } }, secure: OPT_OUT, httponly: OPT_OUT)
         expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Strict")
       end
 
       it "ignores configuration if the cookie is already flagged" do
         raw_cookie = "_session=thisisatest; SameSite=Strict"
-        cookie = Cookie.new(raw_cookie, samesite: { lax: true }, secure: false, httponly: false)
+        cookie = Cookie.new(raw_cookie, samesite: { lax: true }, secure: OPT_OUT, httponly: OPT_OUT)
         expect(cookie.to_s).to eq(raw_cookie)
       end
     end
@@ -119,9 +119,15 @@ module SecureHeaders
       end.to raise_error(CookiesConfigError)
     end
 
-    it "raises an exception when configured without a boolean/Hash" do
+    it "raises an exception when configured without a boolean(true or OPT_OUT)/Hash" do
       expect do
         Cookie.validate_config!(secure: "true")
+      end.to raise_error(CookiesConfigError)
+    end
+
+    it "raises an exception when configured with false" do
+      expect do
+        Cookie.validate_config!(secure: false)
       end.to raise_error(CookiesConfigError)
     end
 

--- a/spec/lib/secure_headers/headers/cookie_spec.rb
+++ b/spec/lib/secure_headers/headers/cookie_spec.rb
@@ -5,37 +5,42 @@ module SecureHeaders
   describe Cookie do
     let(:raw_cookie) { "_session=thisisatest" }
 
-    it "does not tamper with cookies when unconfigured" do
-      cookie = Cookie.new(raw_cookie, {})
+    it "does not tamper with cookies when using OPT_OUT is used" do
+      cookie = Cookie.new(raw_cookie, OPT_OUT)
       expect(cookie.to_s).to eq(raw_cookie)
     end
 
+    it "applies httponly and secure by default" do
+      cookie = Cookie.new(raw_cookie, nil)
+      expect(cookie.to_s).to eq("_session=thisisatest; secure; HttpOnly")
+    end
+
     it "preserves existing attributes" do
-      cookie = Cookie.new("_session=thisisatest; secure", secure: true)
+      cookie = Cookie.new("_session=thisisatest; secure", {secure: true, httponly: false})
       expect(cookie.to_s).to eq("_session=thisisatest; secure")
     end
 
     it "prevents duplicate flagging of attributes" do
-      cookie = Cookie.new("_session=thisisatest; secure", secure: true)
+      cookie = Cookie.new("_session=thisisatest; secure", {secure: true, httponly: false})
       expect(cookie.to_s.scan(/secure/i).count).to eq(1)
     end
 
     context "Secure cookies" do
       context "when configured with a boolean" do
         it "flags cookies as Secure" do
-          cookie = Cookie.new(raw_cookie, secure: true)
+          cookie = Cookie.new(raw_cookie, secure: true, httponly: false)
           expect(cookie.to_s).to eq("_session=thisisatest; secure")
         end
       end
 
       context "when configured with a Hash" do
         it "flags cookies as Secure when whitelisted" do
-          cookie = Cookie.new(raw_cookie, secure: { only: ["_session"]})
+          cookie = Cookie.new(raw_cookie, {secure: { only: ["_session"]}, httponly: false})
           expect(cookie.to_s).to eq("_session=thisisatest; secure")
         end
 
         it "does not flag cookies as Secure when excluded" do
-          cookie = Cookie.new(raw_cookie, secure: { except: ["_session"] })
+          cookie = Cookie.new(raw_cookie, {secure: { except: ["_session"] }, httponly: false})
           expect(cookie.to_s).to eq("_session=thisisatest")
         end
       end
@@ -44,19 +49,19 @@ module SecureHeaders
     context "HttpOnly cookies" do
       context "when configured with a boolean" do
         it "flags cookies as HttpOnly" do
-          cookie = Cookie.new(raw_cookie, httponly: true)
+          cookie = Cookie.new(raw_cookie, httponly: true, secure: false)
           expect(cookie.to_s).to eq("_session=thisisatest; HttpOnly")
         end
       end
 
       context "when configured with a Hash" do
         it "flags cookies as HttpOnly when whitelisted" do
-          cookie = Cookie.new(raw_cookie, httponly: { only: ["_session"]})
+          cookie = Cookie.new(raw_cookie, httponly: { only: ["_session"]}, secure: false)
           expect(cookie.to_s).to eq("_session=thisisatest; HttpOnly")
         end
 
         it "does not flag cookies as HttpOnly when excluded" do
-          cookie = Cookie.new(raw_cookie, httponly: { except: ["_session"] })
+          cookie = Cookie.new(raw_cookie, httponly: { except: ["_session"] }, secure: false)
           expect(cookie.to_s).to eq("_session=thisisatest")
         end
       end
@@ -64,44 +69,44 @@ module SecureHeaders
 
     context "SameSite cookies" do
       it "flags SameSite=Lax" do
-        cookie = Cookie.new(raw_cookie, samesite: { lax: { only: ["_session"] } })
+        cookie = Cookie.new(raw_cookie, samesite: { lax: { only: ["_session"] } }, secure: false, httponly: false)
         expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Lax")
       end
 
       it "flags SameSite=Lax when configured with a boolean" do
-        cookie = Cookie.new(raw_cookie, samesite: { lax: true})
+        cookie = Cookie.new(raw_cookie, samesite: { lax: true}, secure: false, httponly: false)
         expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Lax")
       end
 
       it "does not flag cookies as SameSite=Lax when excluded" do
-        cookie = Cookie.new(raw_cookie, samesite: { lax: { except: ["_session"] } })
+        cookie = Cookie.new(raw_cookie, samesite: { lax: { except: ["_session"] } }, secure: false, httponly: false)
         expect(cookie.to_s).to eq("_session=thisisatest")
       end
 
       it "flags SameSite=Strict" do
-        cookie = Cookie.new(raw_cookie, samesite: { strict: { only: ["_session"] } })
+        cookie = Cookie.new(raw_cookie, samesite: { strict: { only: ["_session"] } }, secure: false, httponly: false)
         expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Strict")
       end
 
       it "does not flag cookies as SameSite=Strict when excluded" do
-        cookie = Cookie.new(raw_cookie, samesite: { strict: { except: ["_session"] } })
+        cookie = Cookie.new(raw_cookie, samesite: { strict: { except: ["_session"] }}, secure: false, httponly: false)
         expect(cookie.to_s).to eq("_session=thisisatest")
       end
 
       it "flags SameSite=Strict when configured with a boolean" do
-        cookie = Cookie.new(raw_cookie, samesite: { strict: true})
+        cookie = Cookie.new(raw_cookie, {samesite: { strict: true}, secure: false, httponly: false})
         expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Strict")
       end
 
       it "flags properly when both lax and strict are configured" do
         raw_cookie = "_session=thisisatest"
-        cookie = Cookie.new(raw_cookie, samesite: { strict: { only: ["_session"] }, lax: { only: ["_additional_session"] } })
+        cookie = Cookie.new(raw_cookie, {samesite: { strict: { only: ["_session"] }, lax: { only: ["_additional_session"] } }, secure: false, httponly: false})
         expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Strict")
       end
 
       it "ignores configuration if the cookie is already flagged" do
         raw_cookie = "_session=thisisatest; SameSite=Strict"
-        cookie = Cookie.new(raw_cookie, samesite: { lax: true })
+        cookie = Cookie.new(raw_cookie, {samesite: { lax: true }, secure: false, httponly: false})
         expect(cookie.to_s).to eq(raw_cookie)
       end
     end

--- a/spec/lib/secure_headers/headers/cookie_spec.rb
+++ b/spec/lib/secure_headers/headers/cookie_spec.rb
@@ -10,13 +10,13 @@ module SecureHeaders
       expect(cookie.to_s).to eq(raw_cookie)
     end
 
-    it "applies httponly and secure by default" do
+    it "applies httponly, secure, and samesite by default" do
       cookie = Cookie.new(raw_cookie, nil)
-      expect(cookie.to_s).to eq("_session=thisisatest; secure; HttpOnly")
+      expect(cookie.to_s).to eq("_session=thisisatest; secure; HttpOnly; SameSite=Lax")
     end
 
     it "preserves existing attributes" do
-      cookie = Cookie.new("_session=thisisatest; secure", secure: true, httponly: OPT_OUT)
+      cookie = Cookie.new("_session=thisisatest; secure", secure: true, httponly: OPT_OUT, samesite: OPT_OUT)
       expect(cookie.to_s).to eq("_session=thisisatest; secure")
     end
 
@@ -28,19 +28,19 @@ module SecureHeaders
     context "Secure cookies" do
       context "when configured with a boolean" do
         it "flags cookies as Secure" do
-          cookie = Cookie.new(raw_cookie, secure: true, httponly: OPT_OUT)
+          cookie = Cookie.new(raw_cookie, secure: true, httponly: OPT_OUT, samesite: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest; secure")
         end
       end
 
       context "when configured with a Hash" do
         it "flags cookies as Secure when whitelisted" do
-          cookie = Cookie.new(raw_cookie, secure: { only: ["_session"]}, httponly: OPT_OUT)
+          cookie = Cookie.new(raw_cookie, secure: { only: ["_session"]}, httponly: OPT_OUT, samesite: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest; secure")
         end
 
         it "does not flag cookies as Secure when excluded" do
-          cookie = Cookie.new(raw_cookie, secure: { except: ["_session"] }, httponly: OPT_OUT)
+          cookie = Cookie.new(raw_cookie, secure: { except: ["_session"] }, httponly: OPT_OUT, samesite: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest")
         end
       end
@@ -49,19 +49,19 @@ module SecureHeaders
     context "HttpOnly cookies" do
       context "when configured with a boolean" do
         it "flags cookies as HttpOnly" do
-          cookie = Cookie.new(raw_cookie, httponly: true, secure: OPT_OUT)
+          cookie = Cookie.new(raw_cookie, httponly: true, secure: OPT_OUT, samesite: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest; HttpOnly")
         end
       end
 
       context "when configured with a Hash" do
         it "flags cookies as HttpOnly when whitelisted" do
-          cookie = Cookie.new(raw_cookie, httponly: { only: ["_session"]}, secure: OPT_OUT)
+          cookie = Cookie.new(raw_cookie, httponly: { only: ["_session"]}, secure: OPT_OUT, samesite: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest; HttpOnly")
         end
 
         it "does not flag cookies as HttpOnly when excluded" do
-          cookie = Cookie.new(raw_cookie, httponly: { except: ["_session"] }, secure: OPT_OUT)
+          cookie = Cookie.new(raw_cookie, httponly: { except: ["_session"] }, secure: OPT_OUT, samesite: OPT_OUT)
           expect(cookie.to_s).to eq("_session=thisisatest")
         end
       end

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -58,7 +58,7 @@ module SecureHeaders
     context "cookies" do
       context "cookies should be flagged" do
         it "flags cookies as secure" do
-          Configuration.default { |config| config.cookies = {secure: true, httponly: OPT_OUT} }
+          Configuration.default { |config| config.cookies = {secure: true, httponly: OPT_OUT, samesite: OPT_OUT} }
           request = Rack::Request.new("HTTPS" => "on")
           _, env = cookie_middleware.call request.env
           expect(env["Set-Cookie"]).to eq("foo=bar; secure")
@@ -67,7 +67,7 @@ module SecureHeaders
 
       context "cookies should not be flagged" do
         it "does not flags cookies as secure" do
-          Configuration.default { |config| config.cookies = {secure: OPT_OUT, httponly: OPT_OUT}  }
+          Configuration.default { |config| config.cookies = {secure: OPT_OUT, httponly: OPT_OUT, samesite: OPT_OUT}  }
           request = Rack::Request.new("HTTPS" => "on")
           _, env = cookie_middleware.call request.env
           expect(env["Set-Cookie"]).to eq("foo=bar")
@@ -77,11 +77,11 @@ module SecureHeaders
 
     context "cookies" do
       it "flags cookies from configuration" do
-        Configuration.default { |config| config.cookies = { secure: true, httponly: true } }
+        Configuration.default { |config| config.cookies = { secure: true, httponly: true, samesite: { lax: true} } }
         request = Rack::Request.new("HTTPS" => "on")
         _, env = cookie_middleware.call request.env
 
-        expect(env["Set-Cookie"]).to eq("foo=bar; secure; HttpOnly")
+        expect(env["Set-Cookie"]).to eq("foo=bar; secure; HttpOnly; SameSite=Lax")
       end
 
       it "flags cookies with a combination of SameSite configurations" do
@@ -96,7 +96,7 @@ module SecureHeaders
       end
 
       it "disables secure cookies for non-https requests" do
-        Configuration.default { |config| config.cookies = { secure: true, httponly: OPT_OUT} }
+        Configuration.default { |config| config.cookies = { secure: true, httponly: OPT_OUT, samesite: OPT_OUT } }
 
         request = Rack::Request.new("HTTPS" => "off")
         _, env = cookie_middleware.call request.env
@@ -104,7 +104,7 @@ module SecureHeaders
       end
 
       it "sets the secure cookie flag correctly on interleaved http/https requests" do
-        Configuration.default { |config| config.cookies = { secure: true, httponly: OPT_OUT } }
+        Configuration.default { |config| config.cookies = { secure: true, httponly: OPT_OUT, samesite: OPT_OUT } }
 
         request = Rack::Request.new("HTTPS" => "off")
         _, env = cookie_middleware.call request.env

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -58,7 +58,7 @@ module SecureHeaders
     context "cookies" do
       context "cookies should be flagged" do
         it "flags cookies as secure" do
-          Configuration.default { |config| config.cookies = { secure: true } }
+          Configuration.default { |config| config.cookies = {secure: true, httponly: false} }
           request = Rack::Request.new("HTTPS" => "on")
           _, env = cookie_middleware.call request.env
           expect(env["Set-Cookie"]).to eq("foo=bar; secure")
@@ -67,7 +67,7 @@ module SecureHeaders
 
       context "cookies should not be flagged" do
         it "does not flags cookies as secure" do
-          Configuration.default { |config| config.cookies = nil }
+          Configuration.default { |config| config.cookies = {secure: false, httponly: false}  }
           request = Rack::Request.new("HTTPS" => "on")
           _, env = cookie_middleware.call request.env
           expect(env["Set-Cookie"]).to eq("foo=bar")
@@ -87,7 +87,7 @@ module SecureHeaders
       it "flags cookies with a combination of SameSite configurations" do
         cookie_middleware = Middleware.new(lambda { |env| [200, env.merge("Set-Cookie" => ["_session=foobar", "_guest=true"]), "app"] })
 
-        Configuration.default { |config| config.cookies = { samesite: { lax: { except: ["_session"] }, strict: { only: ["_session"] } } } }
+        Configuration.default { |config| config.cookies = { samesite: { lax: { except: ["_session"] }, strict: { only: ["_session"] } }, httponly: false, secure: false} }
         request = Rack::Request.new("HTTPS" => "on")
         _, env = cookie_middleware.call request.env
 
@@ -96,7 +96,7 @@ module SecureHeaders
       end
 
       it "disables secure cookies for non-https requests" do
-        Configuration.default { |config| config.cookies = { secure: true } }
+        Configuration.default { |config| config.cookies = { secure: true, httponly: false} }
 
         request = Rack::Request.new("HTTPS" => "off")
         _, env = cookie_middleware.call request.env
@@ -104,7 +104,7 @@ module SecureHeaders
       end
 
       it "sets the secure cookie flag correctly on interleaved http/https requests" do
-        Configuration.default { |config| config.cookies = { secure: true } }
+        Configuration.default { |config| config.cookies = { secure: true, httponly: false } }
 
         request = Rack::Request.new("HTTPS" => "off")
         _, env = cookie_middleware.call request.env

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -58,7 +58,7 @@ module SecureHeaders
     context "cookies" do
       context "cookies should be flagged" do
         it "flags cookies as secure" do
-          Configuration.default { |config| config.cookies = {secure: true, httponly: false} }
+          Configuration.default { |config| config.cookies = {secure: true, httponly: OPT_OUT} }
           request = Rack::Request.new("HTTPS" => "on")
           _, env = cookie_middleware.call request.env
           expect(env["Set-Cookie"]).to eq("foo=bar; secure")
@@ -67,7 +67,7 @@ module SecureHeaders
 
       context "cookies should not be flagged" do
         it "does not flags cookies as secure" do
-          Configuration.default { |config| config.cookies = {secure: false, httponly: false}  }
+          Configuration.default { |config| config.cookies = {secure: OPT_OUT, httponly: OPT_OUT}  }
           request = Rack::Request.new("HTTPS" => "on")
           _, env = cookie_middleware.call request.env
           expect(env["Set-Cookie"]).to eq("foo=bar")
@@ -87,7 +87,7 @@ module SecureHeaders
       it "flags cookies with a combination of SameSite configurations" do
         cookie_middleware = Middleware.new(lambda { |env| [200, env.merge("Set-Cookie" => ["_session=foobar", "_guest=true"]), "app"] })
 
-        Configuration.default { |config| config.cookies = { samesite: { lax: { except: ["_session"] }, strict: { only: ["_session"] } }, httponly: false, secure: false} }
+        Configuration.default { |config| config.cookies = { samesite: { lax: { except: ["_session"] }, strict: { only: ["_session"] } }, httponly: OPT_OUT, secure: OPT_OUT} }
         request = Rack::Request.new("HTTPS" => "on")
         _, env = cookie_middleware.call request.env
 
@@ -96,7 +96,7 @@ module SecureHeaders
       end
 
       it "disables secure cookies for non-https requests" do
-        Configuration.default { |config| config.cookies = { secure: true, httponly: false} }
+        Configuration.default { |config| config.cookies = { secure: true, httponly: OPT_OUT} }
 
         request = Rack::Request.new("HTTPS" => "off")
         _, env = cookie_middleware.call request.env
@@ -104,7 +104,7 @@ module SecureHeaders
       end
 
       it "sets the secure cookie flag correctly on interleaved http/https requests" do
-        Configuration.default { |config| config.cookies = { secure: true, httponly: false } }
+        Configuration.default { |config| config.cookies = { secure: true, httponly: OPT_OUT } }
 
         request = Rack::Request.new("HTTPS" => "off")
         _, env = cookie_middleware.call request.env

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,15 +48,3 @@ end
 def reset_config
   SecureHeaders::Configuration.clear_configurations
 end
-
-def capture_warning
-  begin
-    old_stderr = $stderr
-    $stderr = StringIO.new
-    yield
-    result = $stderr.string
-  ensure
-    $stderr = old_stderr
-  end
-  result
-end


### PR DESCRIPTION
Adds `secure` and `httponly` flags to cookies by default, targeting a 4.0 release tracked by #286. 

/CC @stve @oreoshake 
### Outstanding Questions:

Should 4.0 also include `SameSite=Lax`? 

> [- Default cookies to secure, httponly, samsite=lax](https://github.com/twitter/secureheaders/issues/286#issuecomment-305678390)

### Suggested CHANGELOG entry
(I'm not sure if I should add this to the actual CHANGELOG file b/c I don't know which release this will get pulled into)

> Adds `secure` and `httponly` flags to all cookies by default.



## All Prs

- [x] Has tests
- [x]  Documentation updated

