### PR TITLE
Default samesite: true to mean SameSite=Lax instead of Strict

### DIFF
--- a/lib/secure_headers/headers/cookie.rb
+++ b/lib/secure_headers/headers/cookie.rb
@@ -100,6 +100,10 @@ module SecureHeaders
     def flag_samesite_enforcement?(mode)
       return unless config[:samesite]
 
+      if config[:samesite].is_a?(TrueClass) && mode == :lax
+        return true
+      end
+
       case config[:samesite][mode]
       when Hash
         conditionally_flag?(config[:samesite][mode])

--- a/spec/lib/secure_headers/headers/cookie_spec.rb
+++ b/spec/lib/secure_headers/headers/cookie_spec.rb
@@ -104,6 +104,12 @@ module SecureHeaders
         cookie = Cookie.new(raw_cookie, samesite: { lax: true })
         expect(cookie.to_s).to eq(raw_cookie)
       end
+
+      it "samesite: true sets all cookies to samesite=lax" do
+        raw_cookie = "_session=thisisatest"
+        cookie = Cookie.new(raw_cookie, samesite: true)
+        expect(cookie.to_s).to eq("_session=thisisatest; SameSite=Lax")
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #268 

It looks like setting `samesite: true` broke at some point or was never supported but in #268 it was clear that `Lax` is the more practical default.