### PR TITLE
The smallest typo in comments/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ SecureHeaders::Configuration.default do |config|
     "executionContexts"
   ]
   config.csp = {
-    # "meta" values. these will shaped the header, but the values are not included in the header.
+    # "meta" values. these will shape the header, but the values are not included in the header.
     preserve_schemes: true, # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
 
     # directive values: these values will directly translate into source directives

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -17,7 +17,7 @@ module SecureHeaders
       it "accepts all keys" do
         # (pulled from README)
         config = {
-          # "meta" values. these will shaped the header, but the values are not included in the header.
+          # "meta" values. these will shape the header, but the values are not included in the header.
           report_only:  true,     # default: false
           preserve_schemes: true, # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
 


### PR DESCRIPTION
* [x] ~Has tests~ Documentation needs zero tests
* [x] Documentation updated

Sorry for this tiny PR. It basically just kills a _single_ typo in _two_ places.

🙇 