### PR TITLE
allow opting out of script-src requirement

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -101,9 +101,11 @@ module SecureHeaders
       else
         @config.directive_value(directive)
       end
-      return unless source_list && source_list.any?
-      normalized_source_list = minify_source_list(directive, source_list)
-      [symbol_to_hyphen_case(directive), normalized_source_list].join(" ")
+
+      if source_list != OPT_OUT && source_list&.any?
+        normalized_source_list = minify_source_list(directive, source_list)
+        [symbol_to_hyphen_case(directive), normalized_source_list].join(" ")
+      end
     end
 
     # If a directive contains *, all other values are omitted.

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -102,7 +102,7 @@ module SecureHeaders
         @config.directive_value(directive)
       end
 
-      if source_list != OPT_OUT && source_list&.any?
+      if source_list != OPT_OUT && source_list && source_list.any?
         normalized_source_list = minify_source_list(directive, source_list)
         [symbol_to_hyphen_case(directive), normalized_source_list].join(" ")
       end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -203,7 +203,7 @@ module SecureHeaders
         return if config.nil? || config.opt_out?
         raise ContentSecurityPolicyConfigError.new(":default_src is required") unless config.directive_value(:default_src)
         if config.directive_value(:script_src).nil?
-          raise ContentSecurityPolicyConfigError.new(":script_src is required, falling back to default-src is too dangerous. Use OPT_OUT to override")
+          raise ContentSecurityPolicyConfigError.new(":script_src is required, falling back to default-src is too dangerous. Use `script_src: OPT_OUT` to override")
         end
 
         ContentSecurityPolicyConfig.attrs.each do |key|

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -202,7 +202,10 @@ module SecureHeaders
       def validate_config!(config)
         return if config.nil? || config.opt_out?
         raise ContentSecurityPolicyConfigError.new(":default_src is required") unless config.directive_value(:default_src)
-        raise ContentSecurityPolicyConfigError.new(":script_src is required, falling back to default-src is too dangerous") unless config.directive_value(:script_src)
+        if config.directive_value(:script_src).nil?
+          raise ContentSecurityPolicyConfigError.new(":script_src is required, falling back to default-src is too dangerous. Use OPT_OUT to override")
+        end
+
         ContentSecurityPolicyConfig.attrs.each do |key|
           value = config.directive_value(key)
           next unless value
@@ -342,12 +345,13 @@ module SecureHeaders
       end
 
       def ensure_array_of_strings!(directive, source_expression)
-        unless source_expression.is_a?(Array) && source_expression.compact.all? { |v| v.is_a?(String) }
+        if (!source_expression.is_a?(Array) || !source_expression.compact.all? { |v| v.is_a?(String) }) && source_expression != OPT_OUT
           raise ContentSecurityPolicyConfigError.new("#{directive} must be an array of strings")
         end
       end
 
       def ensure_valid_sources!(directive, source_expression)
+        return if source_expression == OPT_OUT
         source_expression.each do |expression|
           if ContentSecurityPolicy::DEPRECATED_SOURCE_VALUES.include?(expression)
             raise ContentSecurityPolicyConfigError.new("#{directive} contains an invalid keyword source (#{expression}). This value must be single quoted.")

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -51,6 +51,11 @@ module SecureHeaders
         expect(csp.value).to eq("default-src example.org")
       end
 
+      it "does not build directives with a value of OPT_OUT (and bypasses directive requirements)" do
+        csp = ContentSecurityPolicy.new(default_src: %w(https://example.org), script_src: OPT_OUT)
+        expect(csp.value).to eq("default-src example.org")
+      end
+
       it "does not remove schemes from report-uri values" do
         csp = ContentSecurityPolicy.new(default_src: %w(https:), report_uri: %w(https://example.org))
         expect(csp.value).to eq("default-src https:; report-uri https://example.org")

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -57,6 +57,12 @@ module SecureHeaders
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
 
+      it "accepts OPT_OUT as a script-src value" do
+        expect do
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_src: %w('self'), script_src: OPT_OUT))
+        end.to_not raise_error
+      end
+
       it "requires :report_only to be a truthy value" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(report_only: "steve")))


### PR DESCRIPTION
This was a breaking change in 4.x and not having a workaround kind of sucks. I immediately ran into a problem with our APIs CSP (`default-src 'none'`) and adding `script-src 'none'` made me feel like a bad person.

This uses the `OPT_OUT` value to bypass the `script-src` requirement. While falling back to `default-src` can be dangerous for webapps, it would just waste bytes for APIs.

