### PR TITLE
Prevent global cookie OPT_OUT from blowing up in middleware

### DIFF
--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -24,7 +24,7 @@ module SecureHeaders
   class NoOpHeaderConfig
     include Singleton
 
-    def boom(arg = nil)
+    def boom(*args)
       raise "Illegal State: attempted to modify NoOpHeaderConfig. Create a new config instead."
     end
 

--- a/lib/secure_headers/middleware.rb
+++ b/lib/secure_headers/middleware.rb
@@ -38,7 +38,7 @@ module SecureHeaders
 
     # disable Secure cookies for non-https requests
     def override_secure(env, config = {})
-      if scheme(env) != "https"
+      if scheme(env) != "https" && config != OPT_OUT
         config[:secure] = OPT_OUT
       end
 

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -65,6 +65,13 @@ module SecureHeaders
         end
       end
 
+      it "allows opting out of cookie protection with OPT_OUT alone" do
+        Configuration.default { |config| config.cookies = OPT_OUT}
+        request = Rack::Request.new({})
+        _, env = cookie_middleware.call request.env
+        expect(env["Set-Cookie"]).to eq("foo=bar")
+      end
+
       context "cookies should not be flagged" do
         it "does not flags cookies as secure" do
           Configuration.default { |config| config.cookies = {secure: OPT_OUT, httponly: OPT_OUT, samesite: OPT_OUT}  }

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -67,6 +67,10 @@ module SecureHeaders
 
       it "allows opting out of cookie protection with OPT_OUT alone" do
         Configuration.default { |config| config.cookies = OPT_OUT}
+
+        # do NOT make this request https. non-https requests modify a config,
+        # causing an exception when operating on OPT_OUT. This ensures we don't
+        # try to modify the config.
         request = Rack::Request.new({})
         _, env = cookie_middleware.call request.env
         expect(env["Set-Cookie"]).to eq("foo=bar")


### PR DESCRIPTION
When we started requiring the use of `OPT_OUT` for cookie settings to mean "don't touch my cookies," the tests didn't catch the case where the secure flag cannot be set on non-https requests.

When `config[:secure]` executes, it calls the `[]` function which is wired to go `boom`. This bypasses that code block if the value of `config` is `OPT_OUT`.

/cc @anglinb 