### PR TITLE
Fixed URL to 'Upgrading to 4.0' document.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.x
 
-- See the [upgrading to 4.0](upgrading-to-4.0.md) guide. Lots of breaking changes.
+- See the [upgrading to 4.0](upgrading-to-4-0.md) guide. Lots of breaking changes.
 
 ## 3.6.5
 


### PR DESCRIPTION
This fixes the URL to the 'Upgrading to 4.0' document in the CHANGELOG.