### PR TITLE
Distinguish between source lists directives and non-source list directives

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -75,8 +75,8 @@ module SecureHeaders
         case DIRECTIVE_VALUE_TYPES[directive_name]
         when :boolean
           symbol_to_hyphen_case(directive_name) if @config.directive_value(directive_name)
-        when :sandbox_token_list
-          build_sandbox_token_directive(directive_name)
+        when :sandbox_list
+          build_sandbox_list_directive(directive_name)
         when :media_type_list
           build_media_type_list_directive(directive_name)
         when :source_list
@@ -85,36 +85,36 @@ module SecureHeaders
       end.compact.join("; ")
     end
 
-    def build_sandbox_token_directive(directive)
-      if value = @config.directive_value(directive)
-        max_strict_policy = case value
-        when Array
-          value.empty?
-        when true
-          true
-        else
-          false
-        end
+    def build_sandbox_list_directive(directive)
+      return unless sandbox_list = @config.directive_value(directive)
+      max_strict_policy = case sandbox_list
+      when Array
+        sandbox_list.empty?
+      when true
+        true
+      else
+        false
+      end
 
-        # A maximally strict sandbox policy is just the `sandbox` directive,
-        # whith no configuraiton values.
-        if max_strict_policy
-          symbol_to_hyphen_case(directive)
-        else
-          [
-            symbol_to_hyphen_case(directive),
-            @config.directive_value(directive)
-          ].uniq.join(" ")
-        end
+      # A maximally strict sandbox policy is just the `sandbox` directive,
+      # whith no configuraiton values.
+      if max_strict_policy
+        symbol_to_hyphen_case(directive)
+      elsif sandbox_list && sandbox_list.any?
+        [
+          symbol_to_hyphen_case(directive),
+          sandbox_list.uniq
+        ].join(" ")
       end
     end
 
     def build_media_type_list_directive(directive)
-      if value = @config.directive_value(directive)
+      return unless media_type_list = @config.directive_value(directive)
+      if media_type_list && media_type_list.any?
         [
           symbol_to_hyphen_case(directive),
-          @config.directive_value(directive)
-        ].uniq.join(" ")
+          media_type_list.uniq
+        ].join(" ")
       end
     end
 

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -116,18 +116,6 @@ module SecureHeaders
     # everything else is in between.
     BODY_DIRECTIVES = ALL_DIRECTIVES - [DEFAULT_SRC, REPORT_URI]
 
-    # These are directives that do not inherit the default-src value. This is
-    # useful when calling #combine_policies.
-    NON_FETCH_SOURCES = [
-      BASE_URI,
-      FORM_ACTION,
-      FRAME_ANCESTORS,
-      PLUGIN_TYPES,
-      REPORT_URI
-    ]
-
-    FETCH_SOURCES = ALL_DIRECTIVES - NON_FETCH_SOURCES
-
     VARIATIONS = {
       "Chrome" => CHROME_DIRECTIVES,
       "Opera" => CHROME_DIRECTIVES,
@@ -155,14 +143,30 @@ module SecureHeaders
       MANIFEST_SRC              => :source_list,
       MEDIA_SRC                 => :source_list,
       OBJECT_SRC                => :source_list,
-      PLUGIN_TYPES              => :source_list,
+      PLUGIN_TYPES              => :media_type_list,
       REPORT_URI                => :source_list,
-      SANDBOX                   => :source_list,
+      SANDBOX                   => :sandbox_token_list,
       SCRIPT_SRC                => :source_list,
       STYLE_SRC                 => :source_list,
       UPGRADE_INSECURE_REQUESTS => :boolean
     }.freeze
 
+    # These are directives that don't have use a source list, and hence do not
+    # inherit the default-src value.
+    NON_SOURCE_LIST_SOURCES = DIRECTIVE_VALUE_TYPES.select do |directie, type|
+      type != :source_list
+    end.keys.freeze
+
+    # These are directives that take a source list, but that do not inherit
+    # the default-src value.
+    NON_FETCH_SOURCES = [
+      BASE_URI,
+      FORM_ACTION,
+      FRAME_ANCESTORS,
+      REPORT_URI
+    ]
+
+    FETCH_SOURCES = ALL_DIRECTIVES - NON_FETCH_SOURCES - NON_SOURCE_LIST_SOURCES
 
     STAR_REGEXP = Regexp.new(Regexp.escape(STAR))
     HTTP_SCHEME_REGEX = %r{\Ahttps?://}
@@ -264,7 +268,7 @@ module SecureHeaders
       # when each hash contains a value for a given key.
       def merge_policy_additions(original, additions)
         original.merge(additions) do |directive, lhs, rhs|
-          if source_list?(directive)
+          if source_list?(directive) || sandbox_token_list?(directive) || media_type_list?(directive)
             (lhs.to_a + rhs.to_a).compact.uniq
           else
             rhs
@@ -277,15 +281,15 @@ module SecureHeaders
       def populate_fetch_source_with_default!(original, additions)
         # in case we would be appending to an empty directive, fill it with the default-src value
         additions.each_key do |directive|
-          if !original[directive] && ((source_list?(directive) && FETCH_SOURCES.include?(directive)) || nonce_added?(original, additions))
-            if nonce_added?(original, additions)
-              inferred_directive = directive.to_s.gsub(/_nonce/, "_src").to_sym
-              unless original[inferred_directive] || NON_FETCH_SOURCES.include?(inferred_directive)
-                original[inferred_directive] = default_for(directive, original)
-              end
-            else
-              original[directive] = default_for(directive, original)
-            end
+          directive = if nonce_added?(original, additions)
+            directive.to_s.gsub(/_nonce/, "_src").to_sym
+          else
+            directive
+          end
+          # Don't set a default if directive has an existing value
+          next if original[directive]
+          if FETCH_SOURCES.include?(directive)
+            original[directive] = default_for(directive, original)
           end
         end
       end
@@ -302,38 +306,77 @@ module SecureHeaders
             return true
           end
         end
+        return false
       end
 
       def source_list?(directive)
         DIRECTIVE_VALUE_TYPES[directive] == :source_list
       end
 
+      def sandbox_token_list?(directive)
+        DIRECTIVE_VALUE_TYPES[directive] == :sandbox_token_list
+      end
+
+      def media_type_list?(directive)
+        DIRECTIVE_VALUE_TYPES[directive] == :media_type_list
+      end
+
       # Private: Validates that the configuration has a valid type, or that it is a valid
       # source expression.
-      def validate_directive!(directive, source_expression)
+      def validate_directive!(directive, value)
+        ensure_valid_directive!(directive)
         case ContentSecurityPolicy::DIRECTIVE_VALUE_TYPES[directive]
         when :boolean
-          unless boolean?(source_expression)
-            raise ContentSecurityPolicyConfigError.new("#{directive} must be a boolean value")
+          unless boolean?(value)
+            raise ContentSecurityPolicyConfigError.new("#{directive} must be a boolean. Found #{value.class} value")
           end
-        when :string
-          unless source_expression.is_a?(String)
-            raise ContentSecurityPolicyConfigError.new("#{directive} Must be a string. Found #{config.class}: #{config} value")
-          end
+        when :sandbox_token_list
+          validate_sandbox_token_expression!(directive, value)
+        when :media_type_list
+          validate_media_type_expression!(directive, value)
+        when :source_list
+          validate_source_expression!(directive, value)
         else
-          validate_source_expression!(directive, source_expression)
+          raise ContentSecurityPolicyConfigError.new("Unknown directive #{directive}")
+        end
+      end
+
+      # Private: validates that a sandbox token expression:
+      # 1. is an array of strings or optionally `true` (to enable maximal sandboxing)
+      # 2. For arrays, each element is of the form allow-*
+      def validate_sandbox_token_expression!(directive, sandbox_token_expression)
+        # We support sandbox: true to indicate
+        return if boolean?(sandbox_token_expression) && sandbox_token_expression == true
+        ensure_array_of_strings!(directive, sandbox_token_expression)
+        valid = sandbox_token_expression.compact.all? do |v|
+          v.is_a?(String) && v.start_with?("allow-")
+        end
+        if !valid
+          raise ContentSecurityPolicyConfigError.new("#{directive} must be True or an array of zero or more sandbox token strings (ex. allow-forms)")
+        end
+      end
+
+      # Private: validates that a media type expression:
+      # 1. is an array of strings
+      # 2. each element is of the form type/subtype
+      def validate_media_type_expression!(directive, media_type_expression)
+        ensure_array_of_strings!(directive, media_type_expression)
+        valid = media_type_expression.compact.all? do |v|
+          # All media types are of the form: <type from RFC 2045> "/" <subtype from RFC 2045>
+          v =~ /\A.+\/.+\z/
+        end
+        if !valid
+          raise ContentSecurityPolicyConfigError.new("#{directive} must be an array of valid media types (ex. application/pdf)")
         end
       end
 
       # Private: validates that a source expression:
-      # 1. has a valid name
-      # 2. is an array of strings
-      # 3. does not contain any depreated, now invalid values (inline, eval, self, none)
+      # 1. is an array of strings
+      # 2. does not contain any deprecated, now invalid values (inline, eval, self, none)
       #
       # Does not validate the invididual values of the source expression (e.g.
       # script_src => h*t*t*p: will not raise an exception)
       def validate_source_expression!(directive, source_expression)
-        ensure_valid_directive!(directive)
         ensure_array_of_strings!(directive, source_expression)
         ensure_valid_sources!(directive, source_expression)
       end
@@ -344,8 +387,8 @@ module SecureHeaders
         end
       end
 
-      def ensure_array_of_strings!(directive, source_expression)
-        if (!source_expression.is_a?(Array) || !source_expression.compact.all? { |v| v.is_a?(String) }) && source_expression != OPT_OUT
+      def ensure_array_of_strings!(directive, value)
+        if (!value.is_a?(Array) || !value.compact.all? { |v| v.is_a?(String) }) && value != OPT_OUT
           raise ContentSecurityPolicyConfigError.new("#{directive} must be an array of strings")
         end
       end

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -96,6 +96,21 @@ module SecureHeaders
         expect(csp.value).to eq("default-src example.org")
       end
 
+      it "creates maximally strict sandbox policy when passed no sandbox token values" do
+        csp = ContentSecurityPolicy.new(default_src: %w(example.org), sandbox: [])
+        expect(csp.value).to eq("default-src example.org; sandbox")
+      end
+
+      it "creates maximally strict sandbox policy when passed true" do
+        csp = ContentSecurityPolicy.new(default_src: %w(example.org), sandbox: true)
+        expect(csp.value).to eq("default-src example.org; sandbox")
+      end
+
+      it "creates sandbox policy when passed valid sandbox token values" do
+        csp = ContentSecurityPolicy.new(default_src: %w(example.org), sandbox: %w(allow-forms allow-scripts))
+        expect(csp.value).to eq("default-src example.org; sandbox allow-forms allow-scripts")
+      end
+
       it "does not emit a warning when using frame-src" do
         expect(Kernel).to_not receive(:warn)
         ContentSecurityPolicy.new(default_src: %w('self'), frame_src: %w('self')).value
@@ -120,50 +135,52 @@ module SecureHeaders
             block_all_mixed_content: true,
             upgrade_insecure_requests: true,
             script_src: %w(script-src.com),
-            script_nonce: 123456
+            script_nonce: 123456,
+            sandbox: %w(allow-forms),
+            plugin_types: %w(application/pdf)
           })
         end
 
         it "does not filter any directives for Chrome" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:chrome])
-          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; plugin-types plugin-types.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; plugin-types application/pdf; sandbox allow-forms; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
         end
 
         it "does not filter any directives for Opera" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:opera])
-          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; plugin-types plugin-types.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; plugin-types application/pdf; sandbox allow-forms; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
         end
 
         it "filters blocked-all-mixed-content, child-src, and plugin-types for firefox" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:firefox])
-          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; frame-src child-src.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; frame-src child-src.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; sandbox allow-forms; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
         end
 
         it "filters blocked-all-mixed-content, frame-src, and plugin-types for firefox 46 and higher" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:firefox46])
-          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; sandbox allow-forms; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
         end
 
         it "child-src value is copied to frame-src, adds 'unsafe-inline', filters base-uri, blocked-all-mixed-content, upgrade-insecure-requests, child-src, form-action, frame-ancestors, nonce sources, hash sources, and plugin-types for Edge" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:edge])
-          expect(policy.value).to eq("default-src default-src.com; connect-src connect-src.com; font-src font-src.com; frame-src child-src.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; sandbox sandbox.com; script-src script-src.com 'unsafe-inline'; style-src style-src.com; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; connect-src connect-src.com; font-src font-src.com; frame-src child-src.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; sandbox allow-forms; script-src script-src.com 'unsafe-inline'; style-src style-src.com; report-uri report-uri.com")
         end
 
         it "child-src value is copied to frame-src, adds 'unsafe-inline', filters base-uri, blocked-all-mixed-content, upgrade-insecure-requests, child-src, form-action, frame-ancestors, nonce sources, hash sources, and plugin-types for safari" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:safari6])
-          expect(policy.value).to eq("default-src default-src.com; connect-src connect-src.com; font-src font-src.com; frame-src child-src.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; sandbox sandbox.com; script-src script-src.com 'unsafe-inline'; style-src style-src.com; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; connect-src connect-src.com; font-src font-src.com; frame-src child-src.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; sandbox allow-forms; script-src script-src.com 'unsafe-inline'; style-src style-src.com; report-uri report-uri.com")
         end
 
         it "adds 'unsafe-inline', filters  blocked-all-mixed-content, upgrade-insecure-requests, nonce sources, and hash sources for safari 10 and higher" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:safari10])
-          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; plugin-types plugin-types.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; media-src media-src.com; object-src object-src.com; plugin-types application/pdf; sandbox allow-forms; script-src script-src.com 'nonce-123456'; style-src style-src.com; report-uri report-uri.com")
         end
 
         it "falls back to standard Firefox defaults when the useragent version is not present" do
           ua = USER_AGENTS[:firefox].dup
           allow(ua).to receive(:version).and_return(nil)
           policy = ContentSecurityPolicy.new(complex_opts, ua)
-          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; frame-src child-src.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; sandbox sandbox.com; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; frame-src child-src.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; sandbox allow-forms; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
         end
       end
     end

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -111,6 +111,30 @@ module SecureHeaders
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_src: %w(self none inline eval), script_src: %w('self')))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
+
+      it "rejects anything not of the form allow-* as a sandbox value" do
+        expect do
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(sandbox: ["steve"])))
+        end.to raise_error(ContentSecurityPolicyConfigError)
+      end
+
+      it "accepts anything of the form allow-* as a sandbox value " do
+        expect do
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(sandbox: ["allow-foo"])))
+        end.to_not raise_error
+      end
+
+      it "rejects anything not of the form type/subtype as a plugin-type value" do
+        expect do
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(plugin_types: ["steve"])))
+        end.to raise_error(ContentSecurityPolicyConfigError)
+      end
+
+      it "accepts anything of the form type/subtype as a plugin-type value " do
+        expect do
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(plugin_types: ["application/pdf"])))
+        end.to_not raise_error
+      end
     end
 
     describe "#combine_policies" do

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -124,6 +124,12 @@ module SecureHeaders
         end.to_not raise_error
       end
 
+      it "accepts true as a sandbox policy" do
+        expect do
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(sandbox: true)))
+        end.to_not raise_error
+      end
+
       it "rejects anything not of the form type/subtype as a plugin-type value" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(plugin_types: ["steve"])))


### PR DESCRIPTION
The prior behavior tends to default treat directives that are lists as "source lists". But, a source list kind of has specific behavior (ex. they support `*` to mean "all"). So, there are not meaningful for other lists such as `media-type` and `sandbox`. These directives have "lists", but they are unique to their usage. So, we shouldn't treat them like a source list. This PR adds support for `media-type` and `sandbox`. In particular it treats them as follows:

* `sandbox` - Can set a maximally strict policy using either `sandbox: true` or `sandbox: []`. Any other policy requires each element in the list to be of the form `allow-*`.
* `media-type` - Requires that each element in the list be of the form `type/subtype`. 

In addition the the above, I also (I think) simplified some of the surrounding logic. I bumped into places where the existing logic had to be adjusted to account for the new top level directive types anyway. And, as I was refactoring, I think I was able to remove some of the nestedness of what was there. 
