### PR TITLE
Add last missing `SecureHeaders` namespace fix for `OPT_OUT`

### DIFF
--- a/upgrading-to-4-0.md
+++ b/upgrading-to-4-0.md
@@ -15,7 +15,7 @@ config.cookies = {
 }
 
 # nuclear option, just make things work again
-config.cookies = OPT_OUT
+config.cookies = SecureHeaders::OPT_OUT
 ```
 
 ## script_src must be set


### PR DESCRIPTION
I missed this in #361 but didn't notice until _after_ it was merged.