### PR TITLE
Support worker-src CSP directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ SecureHeaders::Configuration.default do |config|
     plugin_types: %w(application/x-shockwave-flash),
     script_src: %w('self'),
     style_src: %w('unsafe-inline'),
+    worker_src: %w('self'),
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
     report_uri: %w(https://report-uri.io/example-csp)
   }

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -38,6 +38,7 @@ module SecureHeaders
       @script_src = nil
       @style_nonce = nil
       @style_src = nil
+      @worker_src = nil
       @upgrade_insecure_requests = nil
 
       from_hash(hash)

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -73,6 +73,7 @@ module SecureHeaders
     MANIFEST_SRC = :manifest_src
     UPGRADE_INSECURE_REQUESTS = :upgrade_insecure_requests
     WORKER_SRC = :worker_src
+    
     DIRECTIVES_3_0 = [
       DIRECTIVES_2_0,
       BLOCK_ALL_MIXED_CONTENT,

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -72,10 +72,12 @@ module SecureHeaders
     BLOCK_ALL_MIXED_CONTENT = :block_all_mixed_content
     MANIFEST_SRC = :manifest_src
     UPGRADE_INSECURE_REQUESTS = :upgrade_insecure_requests
+    WORKER_SRC = :worker_src
     DIRECTIVES_3_0 = [
       DIRECTIVES_2_0,
       BLOCK_ALL_MIXED_CONTENT,
       MANIFEST_SRC,
+      WORKER_SRC,
       UPGRADE_INSECURE_REQUESTS
     ].flatten.freeze
 
@@ -86,6 +88,7 @@ module SecureHeaders
     FIREFOX_UNSUPPORTED_DIRECTIVES = [
       BLOCK_ALL_MIXED_CONTENT,
       CHILD_SRC,
+      WORKER_SRC,
       PLUGIN_TYPES
     ].freeze
 
@@ -95,6 +98,7 @@ module SecureHeaders
 
     FIREFOX_46_UNSUPPORTED_DIRECTIVES = [
       BLOCK_ALL_MIXED_CONTENT,
+      WORKER_SRC,
       PLUGIN_TYPES
     ].freeze
 
@@ -148,6 +152,7 @@ module SecureHeaders
       SANDBOX                   => :sandbox_list,
       SCRIPT_SRC                => :source_list,
       STYLE_SRC                 => :source_list,
+      WORKER_SRC                => :source_list,
       UPGRADE_INSECURE_REQUESTS => :boolean
     }.freeze
 

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -73,7 +73,7 @@ module SecureHeaders
     MANIFEST_SRC = :manifest_src
     UPGRADE_INSECURE_REQUESTS = :upgrade_insecure_requests
     WORKER_SRC = :worker_src
-    
+
     DIRECTIVES_3_0 = [
       DIRECTIVES_2_0,
       BLOCK_ALL_MIXED_CONTENT,

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -143,12 +143,12 @@ module SecureHeaders
 
         it "does not filter any directives for Chrome" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:chrome])
-          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; plugin-types application/pdf; sandbox allow-forms; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; plugin-types application/pdf; sandbox allow-forms; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; worker-src worker-src.com; report-uri report-uri.com")
         end
 
         it "does not filter any directives for Opera" do
           policy = ContentSecurityPolicy.new(complex_opts, USER_AGENTS[:opera])
-          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; plugin-types application/pdf; sandbox allow-forms; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; report-uri report-uri.com")
+          expect(policy.value).to eq("default-src default-src.com; base-uri base-uri.com; block-all-mixed-content; child-src child-src.com; connect-src connect-src.com; font-src font-src.com; form-action form-action.com; frame-ancestors frame-ancestors.com; img-src img-src.com; manifest-src manifest-src.com; media-src media-src.com; object-src object-src.com; plugin-types application/pdf; sandbox allow-forms; script-src script-src.com 'nonce-123456'; style-src style-src.com; upgrade-insecure-requests; worker-src worker-src.com; report-uri report-uri.com")
         end
 
         it "filters blocked-all-mixed-content, child-src, and plugin-types for firefox" do

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -33,6 +33,7 @@ module SecureHeaders
           object_src: %w('self'),
           script_src: %w('self'),
           style_src: %w('unsafe-inline'),
+          worker_src: %w(worker.com),
           base_uri: %w('self'),
           form_action: %w('self' github.com),
           frame_ancestors: %w('none'),


### PR DESCRIPTION
Closes #357 

I'm not sure about Opera support.
`SecureHeaders::PolicyManagment::VARIATIONS` defines same directives in Chrome and Opera, 
but MDN says that Opera doesn't support it.
 
Other than that, I believe everything else is in order.