### PR TITLE
Update Expect-CT to use separator in spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+- Updates `Expect-CT` header to use a comma separator between directives, as specified in the most current spec.
+
 ## 5.0.0
 
 Well this is a little embarassing. 4.0 was supposed to set the secure/httponly/samesite=lax attributes on cookies by default but it didn't. Now it does. - See the [upgrading to 5.0](docs/upgrading-to-5-0.md) guide.

--- a/lib/secure_headers/headers/expect_certificate_transparency.rb
+++ b/lib/secure_headers/headers/expect_certificate_transparency.rb
@@ -49,7 +49,7 @@ module SecureHeaders
         enforced_directive,
         max_age_directive,
         report_uri_directive
-      ].compact.join("; ").strip
+      ].compact.join(", ").strip
     end
 
     def enforced_directive

--- a/spec/lib/secure_headers/headers/expect_certificate_transparency_spec.rb
+++ b/spec/lib/secure_headers/headers/expect_certificate_transparency_spec.rb
@@ -3,13 +3,13 @@ require "spec_helper"
 
 module SecureHeaders
   describe ExpectCertificateTransparency do
-    specify { expect(ExpectCertificateTransparency.new(max_age: 1234, enforce: true).value).to eq("enforce; max-age=1234") }
+    specify { expect(ExpectCertificateTransparency.new(max_age: 1234, enforce: true).value).to eq("enforce, max-age=1234") }
     specify { expect(ExpectCertificateTransparency.new(max_age: 1234, enforce: false).value).to eq("max-age=1234") }
     specify { expect(ExpectCertificateTransparency.new(max_age: 1234, enforce: "yolocopter").value).to eq("max-age=1234") }
-    specify { expect(ExpectCertificateTransparency.new(max_age: 1234, report_uri: "https://report-uri.io/expect-ct").value).to eq("max-age=1234; report-uri=\"https://report-uri.io/expect-ct\"") }
+    specify { expect(ExpectCertificateTransparency.new(max_age: 1234, report_uri: "https://report-uri.io/expect-ct").value).to eq("max-age=1234, report-uri=\"https://report-uri.io/expect-ct\"") }
     specify do
       config = { enforce: true, max_age: 1234, report_uri: "https://report-uri.io/expect-ct" }
-      header_value = "enforce; max-age=1234; report-uri=\"https://report-uri.io/expect-ct\""
+      header_value = "enforce, max-age=1234, report-uri=\"https://report-uri.io/expect-ct\""
       expect(ExpectCertificateTransparency.new(config).value).to eq(header_value)
     end
 


### PR DESCRIPTION
## All PRs:

* [x] Has tests
* [x] Documentation updated

## Update Expect-CT to use separator specified in the current spec

It seems like semicolons were maybe specified at some point, since various articles written (ex. https://scotthelme.co.uk/a-new-security-header-expect-ct/) use semicolon as the delimiter. But, in the current spec (https://tools.ietf.org/html/draft-ietf-httpbis-expect-ct), commas are used. 

/cc @oreoshake - Since we just deployed this, I think I can confirm the semi-colons aren't working, as I didn't see any expect-ct related data when querying chrome://net-internals/#hsts. 