### PR TITLE
Add nonced versions of Rails link/include tags

### DIFF
--- a/docs/per_action_configuration.md
+++ b/docs/per_action_configuration.md
@@ -66,6 +66,12 @@ body {
   background-color: black;
 }
 <% end %>
+
+<%= nonced_javascript_include_tag "include.js" %>
+
+<%= nonced_javascript_pack_tag "pack.js" %>
+
+<%= nonced_stylesheet_link_tag "link.css" %>
 ```
 
 becomes:

--- a/lib/secure_headers/view_helper.rb
+++ b/lib/secure_headers/view_helper.rb
@@ -7,19 +7,43 @@ module SecureHeaders
     class UnexpectedHashedScriptException < StandardError; end
 
     # Public: create a style tag using the content security policy nonce.
-    # Instructs secure_headers to append a nonce to style/script-src directives.
+    # Instructs secure_headers to append a nonce to style-src directive.
     #
     # Returns an html-safe style tag with the nonce attribute.
     def nonced_style_tag(content_or_options = {}, &block)
       nonced_tag(:style, content_or_options, block)
     end
 
+    # Public: create a stylesheet link tag using the content security policy nonce.
+    # Instructs secure_headers to append a nonce to style-src directive.
+    #
+    # Returns an html-safe link tag with the nonce attribute.
+    def nonced_stylesheet_link_tag(*args, &block)
+      stylesheet_link_tag(*args, nonce: content_security_policy_nonce(:style), &block)
+    end
+
     # Public: create a script tag using the content security policy nonce.
-    # Instructs secure_headers to append a nonce to style/script-src directives.
+    # Instructs secure_headers to append a nonce to script-src directive.
     #
     # Returns an html-safe script tag with the nonce attribute.
     def nonced_javascript_tag(content_or_options = {}, &block)
       nonced_tag(:script, content_or_options, block)
+    end
+
+    # Public: create a script src tag using the content security policy nonce.
+    # Instructs secure_headers to append a nonce to script-src directive.
+    #
+    # Returns an html-safe script tag with the nonce attribute.
+    def nonced_javascript_include_tag(*args, &block)
+      javascript_include_tag(*args, nonce: content_security_policy_nonce(:script), &block)
+    end
+
+    # Public: create a script Webpacker pack tag using the content security policy nonce.
+    # Instructs secure_headers to append a nonce to script-src directive.
+    #
+    # Returns an html-safe script tag with the nonce attribute.
+    def nonced_javascript_pack_tag(*args, &block)
+      javascript_pack_tag(*args, nonce: content_security_policy_nonce(:script), &block)
     end
 
     # Public: use the content security policy nonce for this request directly.

--- a/spec/lib/secure_headers/view_helpers_spec.rb
+++ b/spec/lib/secure_headers/view_helpers_spec.rb
@@ -39,6 +39,12 @@ class Message < ERB
   }
 </style>
 
+<%= nonced_javascript_include_tag "include.js" %>
+
+<%= nonced_javascript_pack_tag "pack.js" %>
+
+<%= nonced_stylesheet_link_tag "link.css" %>
+
 TEMPLATE
   end
 
@@ -62,6 +68,16 @@ TEMPLATE
       options = options.map {|k, v| " #{k}=#{v}"}
     end
     "<#{type}#{options}>#{content}</#{type}>"
+  end
+
+  def javascript_include_tag(source, options = {})
+    content_tag(:script, nil, options.merge(src: source))
+  end
+
+  alias_method :javascript_pack_tag, :javascript_include_tag
+
+  def stylesheet_link_tag(source, options = {})
+    content_tag(:link, nil, options.merge(href: source, rel: "stylesheet", media: "screen"))
   end
 
   def result


### PR DESCRIPTION
Adds support for nonced versions of Rails' CSS, JavaScript and Webpacker link/include tags.

* nonced_stylesheet_link_tag
* nonced_javascript_include_tag
* nonced_javascript_pack_tag

## All PRs:

* [x] Has tests
* [x] Documentation updated
