### PR TITLE
Add missing `nonced_stylesheet_pack_tag`

### DIFF
--- a/docs/per_action_configuration.md
+++ b/docs/per_action_configuration.md
@@ -72,6 +72,8 @@ body {
 <%= nonced_javascript_pack_tag "pack.js" %>
 
 <%= nonced_stylesheet_link_tag "link.css" %>
+
+<%= nonced_stylesheet_pack_tag "pack.css" %>
 ```
 
 becomes:

--- a/lib/secure_headers/view_helper.rb
+++ b/lib/secure_headers/view_helper.rb
@@ -19,7 +19,9 @@ module SecureHeaders
     #
     # Returns an html-safe link tag with the nonce attribute.
     def nonced_stylesheet_link_tag(*args, &block)
-      stylesheet_link_tag(*args, nonce: content_security_policy_nonce(:style), &block)
+      opts = extract_options(args).merge(nonce: content_security_policy_nonce(:style))
+
+      stylesheet_link_tag(*args, opts, &block)
     end
 
     # Public: create a script tag using the content security policy nonce.
@@ -34,24 +36,30 @@ module SecureHeaders
     # Instructs secure_headers to append a nonce to script-src directive.
     #
     # Returns an html-safe script tag with the nonce attribute.
-    def nonced_javascript_include_tag(*args, **kwargs, &block)
-      javascript_include_tag(*args, kwargs.merge(nonce: content_security_policy_nonce(:script)), &block)
+    def nonced_javascript_include_tag(*args, &block)
+      opts = extract_options(args).merge(nonce: content_security_policy_nonce(:script))
+
+      javascript_include_tag(*args, opts, &block)
     end
 
     # Public: create a script Webpacker pack tag using the content security policy nonce.
     # Instructs secure_headers to append a nonce to script-src directive.
     #
     # Returns an html-safe script tag with the nonce attribute.
-    def nonced_javascript_pack_tag(*args, **kwargs, &block)
-      javascript_pack_tag(*args, kwargs.merge(nonce: content_security_policy_nonce(:script)), &block)
+    def nonced_javascript_pack_tag(*args, &block)
+      opts = extract_options(args).merge(nonce: content_security_policy_nonce(:script))
+
+      javascript_pack_tag(*args, opts, &block)
     end
 
     # Public: create a stylesheet Webpacker link tag using the content security policy nonce.
     # Instructs secure_headers to append a nonce to style-src directive.
     #
     # Returns an html-safe link tag with the nonce attribute.
-    def nonced_stylesheet_pack_tag(*args, **kwargs, &block)
-      stylesheet_pack_tag(*args, kwargs.merge(nonce: content_security_policy_nonce(:style)), &block)
+    def nonced_stylesheet_pack_tag(*args, &block)
+      opts = extract_options(args).merge(nonce: content_security_policy_nonce(:style))
+
+      stylesheet_pack_tag(*args, opts, &block)
     end
 
     # Public: use the content security policy nonce for this request directly.
@@ -145,6 +153,14 @@ module SecureHeaders
         content_or_options.html_safe # :'(
       end
       content_tag type, content, options.merge(nonce: content_security_policy_nonce(type))
+    end
+
+    def extract_options(args)
+      if args.last.is_a? Hash
+        args.pop
+      else
+        {}
+      end
     end
   end
 end

--- a/lib/secure_headers/view_helper.rb
+++ b/lib/secure_headers/view_helper.rb
@@ -34,16 +34,24 @@ module SecureHeaders
     # Instructs secure_headers to append a nonce to script-src directive.
     #
     # Returns an html-safe script tag with the nonce attribute.
-    def nonced_javascript_include_tag(*args, &block)
-      javascript_include_tag(*args, nonce: content_security_policy_nonce(:script), &block)
+    def nonced_javascript_include_tag(*args, **kwargs, &block)
+      javascript_include_tag(*args, kwargs.merge(nonce: content_security_policy_nonce(:script)), &block)
     end
 
     # Public: create a script Webpacker pack tag using the content security policy nonce.
     # Instructs secure_headers to append a nonce to script-src directive.
     #
     # Returns an html-safe script tag with the nonce attribute.
-    def nonced_javascript_pack_tag(*args, &block)
-      javascript_pack_tag(*args, nonce: content_security_policy_nonce(:script), &block)
+    def nonced_javascript_pack_tag(*args, **kwargs, &block)
+      javascript_pack_tag(*args, kwargs.merge(nonce: content_security_policy_nonce(:script)), &block)
+    end
+
+    # Public: create a stylesheet Webpacker link tag using the content security policy nonce.
+    # Instructs secure_headers to append a nonce to style-src directive.
+    #
+    # Returns an html-safe link tag with the nonce attribute.
+    def nonced_stylesheet_pack_tag(*args, **kwargs, &block)
+      stylesheet_pack_tag(*args, kwargs.merge(nonce: content_security_policy_nonce(:style)), &block)
     end
 
     # Public: use the content security policy nonce for this request directly.

--- a/spec/lib/secure_headers/view_helpers_spec.rb
+++ b/spec/lib/secure_headers/view_helpers_spec.rb
@@ -39,13 +39,13 @@ class Message < ERB
   }
 </style>
 
-<%= nonced_javascript_include_tag "include.js" %>
+<%= nonced_javascript_include_tag "include.js", defer: true %>
 
-<%= nonced_javascript_pack_tag "pack.js", defer: true %>
+<%= nonced_javascript_pack_tag "pack.js", "otherpack.js", defer: true %>
 
-<%= nonced_stylesheet_link_tag "link.css" %>
+<%= nonced_stylesheet_link_tag "link.css", media: :all %>
 
-<%= nonced_stylesheet_pack_tag "pack.css", media: :all %>
+<%= nonced_stylesheet_pack_tag "pack.css", "otherpack.css", media: :all %>
 
 TEMPLATE
   end
@@ -72,14 +72,18 @@ TEMPLATE
     "<#{type}#{options}>#{content}</#{type}>"
   end
 
-  def javascript_include_tag(source, options = {})
-    content_tag(:script, nil, options.merge(src: source))
+  def javascript_include_tag(*sources, **options)
+    sources.map do |source|
+      content_tag(:script, nil, options.merge(src: source))
+    end
   end
 
   alias_method :javascript_pack_tag, :javascript_include_tag
 
-  def stylesheet_link_tag(source, options = {})
-    content_tag(:link, nil, options.merge(href: source, rel: "stylesheet", media: "screen"))
+  def stylesheet_link_tag(*sources, **options)
+    sources.map do |source|
+      content_tag(:link, nil, options.merge(href: source, rel: "stylesheet", media: "screen"))
+    end
   end
 
   alias_method :stylesheet_pack_tag, :stylesheet_link_tag

--- a/spec/lib/secure_headers/view_helpers_spec.rb
+++ b/spec/lib/secure_headers/view_helpers_spec.rb
@@ -41,9 +41,11 @@ class Message < ERB
 
 <%= nonced_javascript_include_tag "include.js" %>
 
-<%= nonced_javascript_pack_tag "pack.js" %>
+<%= nonced_javascript_pack_tag "pack.js", defer: true %>
 
 <%= nonced_stylesheet_link_tag "link.css" %>
+
+<%= nonced_stylesheet_pack_tag "pack.css", media: :all %>
 
 TEMPLATE
   end
@@ -79,6 +81,8 @@ TEMPLATE
   def stylesheet_link_tag(source, options = {})
     content_tag(:link, nil, options.merge(href: source, rel: "stylesheet", media: "screen"))
   end
+
+  alias_method :stylesheet_pack_tag, :stylesheet_link_tag
 
   def result
     super(binding)


### PR DESCRIPTION
Equivalents were added in 1e81a0a.

This also fixes a bug preventing passing any arguments to these tags. Tests were updated with a sample to reflect this. I can split that into a separate PR or separate commits if you prefer.

## All PRs:

* [x] Has tests
* [x] Documentation updated