### PR TITLE
Rewrite the entire notion of named overrides (breaking change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.0
+
+- See the [upgrading to 5.0](docs/upgrading-to-5-0.md) guide for the breaking changes.
+
 ## 5.0.4
 
 - Adds support for `nonced_stylesheet_pack_tag` #373 (@paulfri)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.4
+
+- Adds support for `nonced_stylesheet_pack_tag` #373 (@paulfri)
+
 ## 5.0.3
 
 - Add nonced versions of Rails link/include tags #372 (@steveh)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 6.0.0
+## 6.0
 
-- See the [upgrading to 5.0](docs/upgrading-to-5-0.md) guide for the breaking changes.
+- See the [upgrading to 6.0](docs/upgrading-to-6-0.md) guide for the breaking changes.
 
 ## 5.0.4
 

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ use SecureHeaders::Middleware
 
 ## Configuration
 
-If you do not supply a `default` configuration, exceptions will be raised. If you would like to use a default configuration (which is fairly locked down), just call `SecureHeaders::Configuration.default` without any arguments or block.
+If you do not supply a configuration, a default (which is fairly locked down) will be used.
 
 All `nil` values will fallback to their default values. `SecureHeaders::OPT_OUT` will disable the header entirely.
 
 **Word of caution:**  The following is not a default configuration per se. It serves as a sample implementation of the configuration. You should read more about these headers and determine what is appropriate for your requirements.
 
 ```ruby
-SecureHeaders::Configuration.default do |config|
+SecureHeaders::Configuration.configure do |config|
   config.cookies = {
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ All `nil` values will fallback to their default values. `SecureHeaders::OPT_OUT`
 **Word of caution:**  The following is not a default configuration per se. It serves as a sample implementation of the configuration. You should read more about these headers and determine what is appropriate for your requirements.
 
 ```ruby
-SecureHeaders::Configuration.configure do |config|
+SecureHeaders::Configuration.default do |config|
   config.cookies = {
     secure: true, # mark all cookies as "Secure"
     httponly: true, # mark all cookies as "HttpOnly"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ use SecureHeaders::Middleware
 
 ## Configuration
 
-If you do not supply a configuration, a default (which is fairly locked down) will be used.
+If you do not supply a `default` configuration, exceptions will be raised. If you would like to use a default configuration (which is fairly locked down), just call `SecureHeaders::Configuration.default` without any arguments or block.
 
 All `nil` values will fallback to their default values. `SecureHeaders::OPT_OUT` will disable the header entirely.
 

--- a/docs/upgrading-to-6-0.md
+++ b/docs/upgrading-to-6-0.md
@@ -34,4 +34,4 @@ Prior to 6.0.0 SecureHeaders pre-built and cached the headers that corresponded 
 
 ## Configuration the default configuration more than once will result in an Exception
 
-Prior to 6.0.0 you could conceivably, though unlikely, have `Configure#default` called more than once. Because configurations are dynamic, configuring more than once could result in unexpected behavior. So, as of 6.0.0 we raise a `AlreadyConfiguredError` if the default configuration is setup more than once.
+Prior to 6.0.0 you could conceivably, though unlikely, have `Configure#default` called more than once. Because configurations are dynamic, configuring more than once could result in unexpected behavior. So, as of 6.0.0 we raise `AlreadyConfiguredError` if the default configuration is setup more than once.

--- a/docs/upgrading-to-6-0.md
+++ b/docs/upgrading-to-6-0.md
@@ -1,0 +1,33 @@
+## Named overrides are now dynamically applied
+
+The original implementation of name overrides worked by making a copy of the default policy, applying the overrides, and storing the result for later use. But, this lead to unexpected results if named overrides were combined with a dynamic policy change. If a change was made to the default configuration during a request, followed by a named override, the dynamic changes would be lost. To keep things consistent named overrides have been rewritten to work the same as named appends in that they always operate on the configuration for the current request. As an example:
+
+```ruby
+# specific opt outs
+Configuration.default do |config|
+  config.x_frame_options = OPT_OUT
+end
+
+# Dynamically update the default config for this request
+SecureHeaders.override_x_frame_options(request, "DENY")
+
+SecureHeaders::Configuration.override(:dynamic_override) do |config|
+  config.x_content_type_options = "nosniff"
+end
+
+SecureHeaders.use_secure_headers_override(request, :dynamic_override)
+```
+
+Prior to 6.0.0, the response would NOT include an `X-Frame-Options` header since the named override would be a copy of the default configuration, but with `X-Content-Type-Options` set to `nosniff`. As of 6.0.0, the above code results in both `X-Frame-Options` set to `DENY` AND `X-Content-Type-Options` to `nosniff`.
+
+## `ContentSecurityPolicyConfig#merge` and `ContentSecurityPolicyReportOnlyConfig#merge` work more like `Hash#merge`
+
+These classes are typically not directly instantiated by users of SecureHeaders. But, if you access `config.csp` you end up accessing one of these objects. Prior to 6.0.0, `#merge` worked more like `#append` in that it would combine policies (i.e. if both policies contained the same key the values would be combined rather than overwritten). This was not consistent with `#merge!`, which worked more like ruby's `Hash#merge!` (overwriting duplicate keys). As of 6.0.0, `#merge` works the same as `#merge!`, but returns a new object instead of mutating `self`.
+
+## `Configuration#get` has been removed
+
+This method is not typically directly called by users of SecureHeaders. Given that named overrides are no longer statically stored, fetching them no longer makes sense.
+
+## Configuration headers are no longer cached
+
+Prior to 6.0.0 SecureHeaders prebuilt and cached the headers that corresponded to the default configuration. The same was also done for named overrides. However, now that named overrides are applied dynamically, those can no longer be cached. As a result, caching has been removed in the name of simplicity. Some micro-benchmarks indicate this shouldn't be a performmance problem and will help to elimiate a class of bugs entirely.

--- a/docs/upgrading-to-6-0.md
+++ b/docs/upgrading-to-6-0.md
@@ -18,7 +18,7 @@ end
 SecureHeaders.use_secure_headers_override(request, :dynamic_override)
 ```
 
-Prior to 6.0.0, the response would NOT include an `X-Frame-Options` header since the named override would be a copy of the default configuration, but with `X-Content-Type-Options` set to `nosniff`. As of 6.0.0, the above code results in both `X-Frame-Options` set to `DENY` AND `X-Content-Type-Options` to `nosniff`.
+Prior to 6.0.0, the response would NOT include a `X-Frame-Options` header since the named override would be a copy of the default configuration, but with `X-Content-Type-Options` set to `nosniff`. As of 6.0.0, the above code results in both `X-Frame-Options` set to `DENY` AND `X-Content-Type-Options` to `nosniff`.
 
 ## `ContentSecurityPolicyConfig#merge` and `ContentSecurityPolicyReportOnlyConfig#merge` work more like `Hash#merge`
 
@@ -30,4 +30,8 @@ This method is not typically directly called by users of SecureHeaders. Given th
 
 ## Configuration headers are no longer cached
 
-Prior to 6.0.0 SecureHeaders prebuilt and cached the headers that corresponded to the default configuration. The same was also done for named overrides. However, now that named overrides are applied dynamically, those can no longer be cached. As a result, caching has been removed in the name of simplicity. Some micro-benchmarks indicate this shouldn't be a performmance problem and will help to elimiate a class of bugs entirely.
+Prior to 6.0.0 SecureHeaders pre-built and cached the headers that corresponded to the default configuration. The same was also done for named overrides. However, now that named overrides are applied dynamically, those can no longer be cached. As a result, caching has been removed in the name of simplicity. Some micro-benchmarks indicate this shouldn't be a performance problem and will help to eliminate a class of bugs entirely.
+
+## Configuration the default configuration more than once will result in an Exception
+
+Prior to 6.0.0 you could conceivably, though unlikely, have `Configure#default` called more than once. Because configurations are dynamic, configuring more than once could result in unexpected behavior. So, as of 6.0.0 we raise a `AlreadyConfiguredError` if the default configuration is setup more than once.

--- a/docs/upgrading-to-6-0.md
+++ b/docs/upgrading-to-6-0.md
@@ -18,7 +18,7 @@ end
 SecureHeaders.use_secure_headers_override(request, :dynamic_override)
 ```
 
-Prior to 6.0.0, the response would NOT include a `X-Frame-Options` header since the named override would be a copy of the default configuration, but with `X-Content-Type-Options` set to `nosniff`. As of 6.0.0, the above code results in both `X-Frame-Options` set to `DENY` AND `X-Content-Type-Options` to `nosniff`.
+Prior to 6.0.0, the response would NOT include a `X-Frame-Options` header since the named override would be a copy of the default configuration, but with `X-Content-Type-Options` set to `nosniff`. As of 6.0.0, the above code results in both `X-Frame-Options` set to `DENY` AND `X-Content-Type-Options` set to `nosniff`.
 
 ## `ContentSecurityPolicyConfig#merge` and `ContentSecurityPolicyReportOnlyConfig#merge` work more like `Hash#merge`
 

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -148,6 +148,7 @@ module SecureHeaders
     def header_hash_for(request)
       prevent_dup = true
       config = config_for(request, prevent_dup)
+      config.validate_config!
       user_agent = UserAgent.parse(request.user_agent)
       headers = config.generate_headers(user_agent)
 
@@ -198,7 +199,7 @@ module SecureHeaders
     # Falls back to the global config
     def config_for(request, prevent_dup = false)
       config = request.env[SECURE_HEADERS_CONFIG] ||
-        Configuration.get(Configuration::DEFAULT_CONFIG)
+        Configuration.get
 
 
       # Global configs are frozen, per-request configs are not. When we're not

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -166,7 +166,7 @@ module SecureHeaders
     # name - the name of the previously configured override.
     def use_secure_headers_override(request, name)
       config = config_for(request)
-      config.apply_override(name)
+      config.override(name)
       override_secure_headers_request_config(request, config)
     end
 
@@ -195,7 +195,7 @@ module SecureHeaders
     # Falls back to the global config
     def config_for(request, prevent_dup = false)
       config = request.env[SECURE_HEADERS_CONFIG] ||
-        Configuration.get
+        Configuration.default
 
 
       # Global configs are frozen, per-request configs are not. When we're not

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -165,13 +165,9 @@ module SecureHeaders
     #
     # name - the name of the previously configured override.
     def use_secure_headers_override(request, name)
-      if override = Configuration.overrides(name)
-        config = config_for(request)
-        config.instance_eval(&override)
-        override_secure_headers_request_config(request, config)
-      else
-        raise ArgumentError.new("no override by the name of #{name} has been configured")
-      end
+      config = config_for(request)
+      config.apply_override(name)
+      override_secure_headers_request_config(request, config)
     end
 
     # Public: gets or creates a nonce for CSP.

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "secure_headers/configuration"
 require "secure_headers/hash_helper"
 require "secure_headers/headers/cookie"
 require "secure_headers/headers/public_key_pins"
@@ -18,6 +17,7 @@ require "secure_headers/railtie"
 require "secure_headers/view_helper"
 require "useragent"
 require "singleton"
+require "secure_headers/configuration"
 
 # All headers (except for hpkp) have a default value. Provide SecureHeaders::OPT_OUT
 # or ":optout_of_protection" as a config value to disable a given header
@@ -52,29 +52,9 @@ module SecureHeaders
   HTTPS = "https".freeze
   CSP = ContentSecurityPolicy
 
-  ALL_HEADER_CLASSES = [
-    ExpectCertificateTransparency,
-    ClearSiteData,
-    ContentSecurityPolicyConfig,
-    ContentSecurityPolicyReportOnlyConfig,
-    StrictTransportSecurity,
-    PublicKeyPins,
-    ReferrerPolicy,
-    XContentTypeOptions,
-    XDownloadOptions,
-    XFrameOptions,
-    XPermittedCrossDomainPolicies,
-    XXssProtection
-  ].freeze
-
-  ALL_HEADERS_BESIDES_CSP = (
-    ALL_HEADER_CLASSES -
-      [ContentSecurityPolicyConfig, ContentSecurityPolicyReportOnlyConfig]
-  ).freeze
-
   # Headers set on http requests (excludes STS and HPKP)
-  HTTP_HEADER_CLASSES =
-    (ALL_HEADER_CLASSES - [StrictTransportSecurity, PublicKeyPins]).freeze
+  HTTPS_HEADER_CLASSES =
+    [StrictTransportSecurity, PublicKeyPins].freeze
 
   class << self
     # Public: override a given set of directives for the current request. If a
@@ -153,7 +133,7 @@ module SecureHeaders
     # Public: opts out of setting all headers by telling secure_headers to use
     # the NOOP configuration.
     def opt_out_of_all_protection(request)
-      use_secure_headers_override(request, Configuration::NOOP_CONFIGURATION)
+      use_secure_headers_override(request, Configuration::NOOP_OVERRIDE)
     end
 
     # Public: Builds the hash of headers that should be applied base on the
@@ -168,27 +148,15 @@ module SecureHeaders
     def header_hash_for(request)
       prevent_dup = true
       config = config_for(request, prevent_dup)
-      headers = config.cached_headers
       user_agent = UserAgent.parse(request.user_agent)
+      headers = config.generate_headers(user_agent)
 
-      if !config.csp.opt_out? && config.csp.modified?
-        headers = update_cached_csp(config.csp, headers, user_agent)
-      end
-
-      if !config.csp_report_only.opt_out? && config.csp_report_only.modified?
-        headers = update_cached_csp(config.csp_report_only, headers, user_agent)
-      end
-
-      header_classes_for(request).each_with_object({}) do |klass, hash|
-        if header = headers[klass::CONFIG_KEY]
-          header_name, value = if klass == ContentSecurityPolicyConfig || klass == ContentSecurityPolicyReportOnlyConfig
-            csp_header_for_ua(header, user_agent)
-          else
-            header
-          end
-          hash[header_name] = value
+      if request.scheme != HTTPS
+        HTTPS_HEADER_CLASSES.each do |klass|
+          headers.delete(klass::HEADER_NAME)
         end
       end
+      headers
     end
 
     # Public: specify which named override will be used for this request.
@@ -196,7 +164,9 @@ module SecureHeaders
     #
     # name - the name of the previously configured override.
     def use_secure_headers_override(request, name)
-      if config = Configuration.get(name)
+      if override = Configuration.overrides(name)
+        config = config_for(request)
+        config.instance_eval(&override)
         override_secure_headers_request_config(request, config)
       else
         raise ArgumentError.new("no override by the name of #{name} has been configured")
@@ -284,35 +254,6 @@ module SecureHeaders
     # Returns the config.
     def override_secure_headers_request_config(request, config)
       request.env[SECURE_HEADERS_CONFIG] = config
-    end
-
-    # Private: determines which headers are applicable to a given request.
-    #
-    # Returns a list of classes whose corresponding header values are valid for
-    # this request.
-    def header_classes_for(request)
-      if request.scheme == HTTPS
-        ALL_HEADER_CLASSES
-      else
-        HTTP_HEADER_CLASSES
-      end
-    end
-
-    def update_cached_csp(config, headers, user_agent)
-      headers = Configuration.send(:deep_copy, headers)
-      headers[config.class::CONFIG_KEY] = {}
-      variation = ContentSecurityPolicy.ua_to_variation(user_agent)
-      headers[config.class::CONFIG_KEY][variation] = ContentSecurityPolicy.make_header(config, user_agent)
-      headers
-    end
-
-    # Private: chooses the applicable CSP header for the provided user agent.
-    #
-    # headers - a hash of header_config_key => [header_name, header_value]
-    #
-    # Returns a CSP [header, value] array
-    def csp_header_for_ua(headers, user_agent)
-      headers[ContentSecurityPolicy.ua_to_variation(user_agent)]
     end
   end
 

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -195,7 +195,7 @@ module SecureHeaders
     # Falls back to the global config
     def config_for(request, prevent_dup = false)
       config = request.env[SECURE_HEADERS_CONFIG] ||
-        Configuration.default
+        Configuration.send(:default_config)
 
 
       # Global configs are frozen, per-request configs are not. When we're not

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -167,6 +167,18 @@ module SecureHeaders
       copy
     end
 
+    # Public: Apply a named override to the current config
+    #
+    # Returns self
+    def apply_override(name)
+      if override = self.class.overrides(name)
+        instance_eval(&override)
+      else
+        raise ArgumentError.new("no override by the name of #{name} has been configured")
+      end
+      self
+    end
+
     def generate_headers(user_agent)
       headers = {}
       HEADERABLE_ATTRIBUTES.each do |attr|

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -62,6 +62,10 @@ module SecureHeaders
         @appends[name] = block
       end
 
+      def dup
+        default_config.dup
+      end
+
       private
 
       # Public: perform a basic deep dup. The shallow copy provided by dup/clone

--- a/lib/secure_headers/headers/clear_site_data.rb
+++ b/lib/secure_headers/headers/clear_site_data.rb
@@ -11,8 +11,6 @@ module SecureHeaders
     EXECUTION_CONTEXTS = "executionContexts".freeze
     ALL_TYPES = [CACHE, COOKIES, STORAGE, EXECUTION_CONTEXTS]
 
-    CONFIG_KEY = :clear_site_data
-
     class << self
       # Public: make an Clear-Site-Data header name, value pair
       #

--- a/lib/secure_headers/headers/clear_site_data.rb
+++ b/lib/secure_headers/headers/clear_site_data.rb
@@ -17,7 +17,7 @@ module SecureHeaders
       # Public: make an Clear-Site-Data header name, value pair
       #
       # Returns nil if not configured, returns header name and value if configured.
-      def make_header(config = nil)
+      def make_header(config = nil, user_agent = nil)
         case config
         when nil, OPT_OUT, []
           # noop
@@ -48,7 +48,7 @@ module SecureHeaders
       #
       # Returns a String of quoted values that are comma separated.
       def make_header_value(types)
-        types.map { |t| "\"#{t}\""}.join(", ")
+        types.map { |t| "\"#{t}\"" }.join(", ")
       end
     end
   end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -13,6 +13,7 @@ module SecureHeaders
     FALLBACK_VERSION = ::UserAgent::Version.new("0")
 
     def initialize(config = nil, user_agent = OTHER)
+      user_agent ||= OTHER
       @config = if config.is_a?(Hash)
         if config[:report_only]
           ContentSecurityPolicyReportOnlyConfig.new(config || DEFAULT_CONFIG)

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -54,7 +54,10 @@ module SecureHeaders
     end
 
     def merge(new_hash)
-      ContentSecurityPolicy.combine_policies(self.to_h, new_hash)
+      new_config = self.dup
+      puts new_config.inspect
+      new_config.send(:from_hash, new_hash)
+      new_config
     end
 
     def merge!(new_hash)

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -2,7 +2,6 @@
 module SecureHeaders
   module DynamicConfig
     def self.included(base)
-      base.send(:attr_writer, :modified)
       base.send(:attr_reader, *base.attrs)
       base.attrs.each do |attr|
         base.send(:define_method, "#{attr}=") do |value|
@@ -42,7 +41,6 @@ module SecureHeaders
       @upgrade_insecure_requests = nil
 
       from_hash(hash)
-      @modified = false
     end
 
     def update_directive(directive, value)
@@ -53,10 +51,6 @@ module SecureHeaders
       if self.class.attrs.include?(directive)
         self.send(directive)
       end
-    end
-
-    def modified?
-      @modified
     end
 
     def merge(new_hash)
@@ -109,11 +103,7 @@ module SecureHeaders
     def write_attribute(attr, value)
       value = value.dup if PolicyManagement::DIRECTIVE_VALUE_TYPES[attr] == :source_list
       attr_variable = "@#{attr}"
-      prev_value = self.instance_variable_get(attr_variable)
       self.instance_variable_set(attr_variable, value)
-      if prev_value != value
-        @modified = true
-      end
     end
   end
 

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -55,7 +55,6 @@ module SecureHeaders
 
     def merge(new_hash)
       new_config = self.dup
-      puts new_config.inspect
       new_config.send(:from_hash, new_hash)
       new_config
     end
@@ -141,7 +140,6 @@ module SecureHeaders
   end
 
   class ContentSecurityPolicyReportOnlyConfig < ContentSecurityPolicyConfig
-    CONFIG_KEY = :csp_report_only
     HEADER_NAME = "Content-Security-Policy-Report-Only".freeze
 
     def report_only?

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -112,7 +112,6 @@ module SecureHeaders
 
   class ContentSecurityPolicyConfigError < StandardError; end
   class ContentSecurityPolicyConfig
-    CONFIG_KEY = :csp
     HEADER_NAME = "Content-Security-Policy".freeze
 
     ATTRS = PolicyManagement::ALL_DIRECTIVES + PolicyManagement::META_CONFIGS + PolicyManagement::NONCES

--- a/lib/secure_headers/headers/expect_certificate_transparency.rb
+++ b/lib/secure_headers/headers/expect_certificate_transparency.rb
@@ -4,7 +4,6 @@ module SecureHeaders
 
   class ExpectCertificateTransparency
     HEADER_NAME = "Expect-CT".freeze
-    CONFIG_KEY  = :expect_certificate_transparency
     INVALID_CONFIGURATION_ERROR = "config must be a hash.".freeze
     INVALID_ENFORCE_VALUE_ERROR = "enforce must be a boolean".freeze
     REQUIRED_MAX_AGE_ERROR      = "max-age is a required directive.".freeze

--- a/lib/secure_headers/headers/expect_certificate_transparency.rb
+++ b/lib/secure_headers/headers/expect_certificate_transparency.rb
@@ -15,8 +15,8 @@ module SecureHeaders
       #
       # Returns nil if not configured, returns header name and value if
       # configured.
-      def make_header(config)
-        return if config.nil?
+      def make_header(config, use_agent = nil)
+        return if config.nil? || config == OPT_OUT
 
         header = new(config)
         [HEADER_NAME, header.value]

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -200,7 +200,7 @@ module SecureHeaders
       #
       # Returns a default policy if no configuration is provided, or a
       # header name and value based on the config.
-      def make_header(config, user_agent)
+      def make_header(config, user_agent = nil)
         return if config.nil? || config == OPT_OUT
         header = new(config, user_agent)
         [header.name, header.value]

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -216,12 +216,22 @@ module SecureHeaders
         if config.directive_value(:script_src).nil?
           raise ContentSecurityPolicyConfigError.new(":script_src is required, falling back to default-src is too dangerous. Use `script_src: OPT_OUT` to override")
         end
+        if !config.report_only? && config.directive_value(:report_only)
+          raise ContentSecurityPolicyConfigError.new("Only the csp_report_only config should  sset :report_only to true")
+        end
+
+        if config.report_only? && config.directive_value(:report_only) == false
+          raise ContentSecurityPolicyConfigError.new("csp_report_only config must have :report_only set to true")
+        end
 
         ContentSecurityPolicyConfig.attrs.each do |key|
           value = config.directive_value(key)
           next unless value
+
           if META_CONFIGS.include?(key)
             raise ContentSecurityPolicyConfigError.new("#{key} must be a boolean value") unless boolean?(value) || value.nil?
+          elsif NONCES.include?(key)
+            raise ContentSecurityPolicyConfigError.new("#{key} must be a non-nil value") if value.nil?
           else
             validate_directive!(key, value)
           end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -217,7 +217,7 @@ module SecureHeaders
           raise ContentSecurityPolicyConfigError.new(":script_src is required, falling back to default-src is too dangerous. Use `script_src: OPT_OUT` to override")
         end
         if !config.report_only? && config.directive_value(:report_only)
-          raise ContentSecurityPolicyConfigError.new("Only the csp_report_only config should  sset :report_only to true")
+          raise ContentSecurityPolicyConfigError.new("Only the csp_report_only config should set :report_only to true")
         end
 
         if config.report_only? && config.directive_value(:report_only) == false

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -201,6 +201,7 @@ module SecureHeaders
       # Returns a default policy if no configuration is provided, or a
       # header name and value based on the config.
       def make_header(config, user_agent)
+        return if config.nil? || config == OPT_OUT
         header = new(config, user_agent)
         [header.name, header.value]
       end

--- a/lib/secure_headers/headers/public_key_pins.rb
+++ b/lib/secure_headers/headers/public_key_pins.rb
@@ -5,7 +5,6 @@ module SecureHeaders
     HEADER_NAME = "Public-Key-Pins".freeze
     REPORT_ONLY = "Public-Key-Pins-Report-Only".freeze
     HASH_ALGORITHMS = [:sha256].freeze
-    CONFIG_KEY = :hpkp
 
 
     class << self

--- a/lib/secure_headers/headers/public_key_pins.rb
+++ b/lib/secure_headers/headers/public_key_pins.rb
@@ -12,8 +12,8 @@ module SecureHeaders
       # Public: make an hpkp header name, value pair
       #
       # Returns nil if not configured, returns header name and value if configured.
-      def make_header(config)
-        return if config.nil?
+      def make_header(config, user_agent = nil)
+        return if config.nil? || config == OPT_OUT
         header = new(config)
         [header.name, header.value]
       end

--- a/lib/secure_headers/headers/referrer_policy.rb
+++ b/lib/secure_headers/headers/referrer_policy.rb
@@ -21,7 +21,8 @@ module SecureHeaders
       #
       # Returns a default header if no configuration is provided, or a
       # header name and value based on the config.
-      def make_header(config = nil)
+      def make_header(config = nil, user_agent = nil)
+        return if config == OPT_OUT
         config ||= DEFAULT_VALUE
         [HEADER_NAME, Array(config).join(", ")]
       end

--- a/lib/secure_headers/headers/referrer_policy.rb
+++ b/lib/secure_headers/headers/referrer_policy.rb
@@ -14,7 +14,6 @@ module SecureHeaders
       origin-when-cross-origin
       unsafe-url
     )
-    CONFIG_KEY = :referrer_policy
 
     class << self
       # Public: generate an Referrer Policy header.

--- a/lib/secure_headers/headers/strict_transport_security.rb
+++ b/lib/secure_headers/headers/strict_transport_security.rb
@@ -8,7 +8,6 @@ module SecureHeaders
     DEFAULT_VALUE = "max-age=" + HSTS_MAX_AGE
     VALID_STS_HEADER = /\Amax-age=\d+(; includeSubdomains)?(; preload)?\z/i
     MESSAGE = "The config value supplied for the HSTS header was invalid. Must match #{VALID_STS_HEADER}"
-    CONFIG_KEY = :hsts
 
     class << self
       # Public: generate an hsts header name, value pair.

--- a/lib/secure_headers/headers/strict_transport_security.rb
+++ b/lib/secure_headers/headers/strict_transport_security.rb
@@ -15,7 +15,8 @@ module SecureHeaders
       #
       # Returns a default header if no configuration is provided, or a
       # header name and value based on the config.
-      def make_header(config = nil)
+      def make_header(config = nil, user_agent = nil)
+        return if config == OPT_OUT
         [HEADER_NAME, config || DEFAULT_VALUE]
       end
 

--- a/lib/secure_headers/headers/x_content_type_options.rb
+++ b/lib/secure_headers/headers/x_content_type_options.rb
@@ -12,7 +12,8 @@ module SecureHeaders
       #
       # Returns a default header if no configuration is provided, or a
       # header name and value based on the config.
-      def make_header(config = nil)
+      def make_header(config = nil, user_agent = nil)
+        return if config == OPT_OUT
         [HEADER_NAME, config || DEFAULT_VALUE]
       end
 

--- a/lib/secure_headers/headers/x_content_type_options.rb
+++ b/lib/secure_headers/headers/x_content_type_options.rb
@@ -5,7 +5,6 @@ module SecureHeaders
   class XContentTypeOptions
     HEADER_NAME = "X-Content-Type-Options".freeze
     DEFAULT_VALUE = "nosniff"
-    CONFIG_KEY = :x_content_type_options
 
     class << self
       # Public: generate an X-Content-Type-Options header.

--- a/lib/secure_headers/headers/x_download_options.rb
+++ b/lib/secure_headers/headers/x_download_options.rb
@@ -11,7 +11,8 @@ module SecureHeaders
       #
       # Returns a default header if no configuration is provided, or a
       # header name and value based on the config.
-      def make_header(config = nil)
+      def make_header(config = nil, user_agent = nil)
+        return if config == OPT_OUT
         [HEADER_NAME, config || DEFAULT_VALUE]
       end
 

--- a/lib/secure_headers/headers/x_download_options.rb
+++ b/lib/secure_headers/headers/x_download_options.rb
@@ -4,7 +4,6 @@ module SecureHeaders
   class XDownloadOptions
     HEADER_NAME = "X-Download-Options".freeze
     DEFAULT_VALUE = "noopen"
-    CONFIG_KEY = :x_download_options
 
     class << self
       # Public: generate an X-Download-Options header.

--- a/lib/secure_headers/headers/x_frame_options.rb
+++ b/lib/secure_headers/headers/x_frame_options.rb
@@ -3,7 +3,6 @@ module SecureHeaders
   class XFOConfigError < StandardError; end
   class XFrameOptions
     HEADER_NAME = "X-Frame-Options".freeze
-    CONFIG_KEY = :x_frame_options
     SAMEORIGIN = "sameorigin"
     DENY = "deny"
     ALLOW_FROM = "allow-from"

--- a/lib/secure_headers/headers/x_frame_options.rb
+++ b/lib/secure_headers/headers/x_frame_options.rb
@@ -16,7 +16,7 @@ module SecureHeaders
       #
       # Returns a default header if no configuration is provided, or a
       # header name and value based on the config.
-      def make_header(config = nil)
+      def make_header(config = nil, user_agent = nil)
         return if config == OPT_OUT
         [HEADER_NAME, config || DEFAULT_VALUE]
       end

--- a/lib/secure_headers/headers/x_permitted_cross_domain_policies.rb
+++ b/lib/secure_headers/headers/x_permitted_cross_domain_policies.rb
@@ -12,7 +12,8 @@ module SecureHeaders
       #
       # Returns a default header if no configuration is provided, or a
       # header name and value based on the config.
-      def make_header(config = nil)
+      def make_header(config = nil, user_agent = nil)
+        return if config == OPT_OUT
         [HEADER_NAME, config || DEFAULT_VALUE]
       end
 

--- a/lib/secure_headers/headers/x_permitted_cross_domain_policies.rb
+++ b/lib/secure_headers/headers/x_permitted_cross_domain_policies.rb
@@ -5,7 +5,6 @@ module SecureHeaders
     HEADER_NAME = "X-Permitted-Cross-Domain-Policies".freeze
     DEFAULT_VALUE = "none"
     VALID_POLICIES = %w(all none master-only by-content-type by-ftp-filename)
-    CONFIG_KEY = :x_permitted_cross_domain_policies
 
     class << self
       # Public: generate an X-Permitted-Cross-Domain-Policies header.

--- a/lib/secure_headers/headers/x_xss_protection.rb
+++ b/lib/secure_headers/headers/x_xss_protection.rb
@@ -12,7 +12,8 @@ module SecureHeaders
       #
       # Returns a default header if no configuration is provided, or a
       # header name and value based on the config.
-      def make_header(config = nil)
+      def make_header(config = nil, user_agent = nil)
+        return if config == OPT_OUT
         [HEADER_NAME, config || DEFAULT_VALUE]
       end
 

--- a/lib/secure_headers/headers/x_xss_protection.rb
+++ b/lib/secure_headers/headers/x_xss_protection.rb
@@ -4,8 +4,7 @@ module SecureHeaders
   class XXssProtection
     HEADER_NAME = "X-XSS-Protection".freeze
     DEFAULT_VALUE = "1; mode=block"
-    VALID_X_XSS_HEADER = /\A[01](; mode=block)?(; report=.*)?\z/i
-    CONFIG_KEY = :x_xss_protection
+    VALID_X_XSS_HEADER = /\A[01](; mode=block)?(; report=.*)?\z/
 
     class << self
       # Public: generate an X-Xss-Protection header.

--- a/secure_headers.gemspec
+++ b/secure_headers.gemspec
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 Gem::Specification.new do |gem|
   gem.name          = "secure_headers"
-  gem.version       = "5.0.4"
+  gem.version       = "6.0.0"
   gem.authors       = ["Neil Matatall"]
   gem.email         = ["neil.matatall@gmail.com"]
   gem.description   = "Manages application of security headers with many safe defaults."

--- a/secure_headers.gemspec
+++ b/secure_headers.gemspec
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 Gem::Specification.new do |gem|
   gem.name          = "secure_headers"
-  gem.version       = "5.0.3"
+  gem.version       = "5.0.4"
   gem.authors       = ["Neil Matatall"]
   gem.email         = ["neil.matatall@gmail.com"]
   gem.description   = "Manages application of security headers with many safe defaults."

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -5,7 +5,6 @@ module SecureHeaders
   describe Configuration do
     before(:each) do
       reset_config
-      Configuration.default
     end
 
     it "has a default config" do
@@ -13,6 +12,7 @@ module SecureHeaders
     end
 
     it "has an 'noop' override" do
+      Configuration.default
       expect(Configuration.overrides(Configuration::NOOP_OVERRIDE)).to_not be_nil
     end
 
@@ -41,7 +41,7 @@ module SecureHeaders
         config.cookies = OPT_OUT
       end
 
-      config = Configuration.get
+      config = Configuration.default
       expect(config.cookies).to eq(OPT_OUT)
     end
 
@@ -50,7 +50,7 @@ module SecureHeaders
         config.cookies = {httponly: true, secure: true, samesite: {lax: false}}
       end
 
-      config = Configuration.get
+      config = Configuration.default
       expect(config.cookies).to eq({httponly: true, secure: true, samesite: {lax: false}})
     end
   end

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -9,7 +9,7 @@ module SecureHeaders
     end
 
     it "has a default config" do
-      expect(Configuration.get(Configuration::DEFAULT_CONFIG)).to_not be_nil
+      expect(Configuration.default).to_not be_nil
     end
 
     it "has an 'noop' override" do

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -41,7 +41,7 @@ module SecureHeaders
         config.cookies = OPT_OUT
       end
 
-      config = Configuration.default
+      config = Configuration.send(:default_config)
       expect(config.cookies).to eq(OPT_OUT)
     end
 
@@ -50,7 +50,7 @@ module SecureHeaders
         config.cookies = {httponly: true, secure: true, samesite: {lax: false}}
       end
 
-      config = Configuration.default
+      config = Configuration.send(:default_config)
       expect(config.cookies).to eq({httponly: true, secure: true, samesite: {lax: false}})
     end
   end

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -16,6 +16,16 @@ module SecureHeaders
       expect(Configuration.overrides(Configuration::NOOP_OVERRIDE)).to_not be_nil
     end
 
+    it "dup results in a copy of the default config" do
+      Configuration.default
+      original_configuration = Configuration.send(:default_config)
+      configuration = Configuration.dup
+      expect(original_configuration).not_to be(configuration)
+      Configuration::CONFIG_ATTRIBUTES.each do |attr|
+        expect(original_configuration.send(attr)).to eq(configuration.send(attr))
+      end
+    end
+
     it "stores an override" do
       Configuration.override(:test_override) do |config|
         config.x_frame_options = "DENY"
@@ -41,7 +51,7 @@ module SecureHeaders
         config.cookies = OPT_OUT
       end
 
-      config = Configuration.send(:default_config)
+      config = Configuration.dup
       expect(config.cookies).to eq(OPT_OUT)
     end
 
@@ -50,7 +60,7 @@ module SecureHeaders
         config.cookies = {httponly: true, secure: true, samesite: {lax: false}}
       end
 
-      config = Configuration.send(:default_config)
+      config = Configuration.dup
       expect(config.cookies).to eq({httponly: true, secure: true, samesite: {lax: false}})
     end
   end

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -12,76 +12,16 @@ module SecureHeaders
       expect(Configuration.get(Configuration::DEFAULT_CONFIG)).to_not be_nil
     end
 
-    it "has an 'noop' config" do
-      expect(Configuration.get(Configuration::NOOP_CONFIGURATION)).to_not be_nil
+    it "has an 'noop' override" do
+      expect(Configuration.overrides(Configuration::NOOP_OVERRIDE)).to_not be_nil
     end
 
-    it "precomputes headers upon creation" do
-      default_config = Configuration.get(Configuration::DEFAULT_CONFIG)
-      header_hash = default_config.cached_headers.each_with_object({}) do |(key, value), hash|
-        header_name, header_value = if key == :csp
-          value["Chrome"]
-        else
-          value
-        end
-
-        hash[header_name] = header_value
-      end
-      expect_default_values(header_hash)
-    end
-
-    it "copies config values when duping" do
-      Configuration.override(:test_override, Configuration::NOOP_CONFIGURATION) do
-        # do nothing, just copy it
-      end
-
-      config = Configuration.get(:test_override)
-      noop = Configuration.get(Configuration::NOOP_CONFIGURATION)
-      [:csp, :csp_report_only, :cookies].each do |key|
-        expect(config.send(key)).to eq(noop.send(key))
-      end
-    end
-
-    it "regenerates cached headers when building an override" do
-      Configuration.override(:test_override) do |config|
-        config.x_content_type_options = OPT_OUT
-      end
-
-      expect(Configuration.get.cached_headers).to_not eq(Configuration.get(:test_override).cached_headers)
-    end
-
-    it "stores an override of the global config" do
+    it "stores an override" do
       Configuration.override(:test_override) do |config|
         config.x_frame_options = "DENY"
       end
 
-      expect(Configuration.get(:test_override)).to_not be_nil
-    end
-
-    it "deep dup's config values when overriding so the original cannot be modified" do
-      Configuration.override(:override) do |config|
-        config.csp[:default_src] << "'self'"
-      end
-
-      default = Configuration.get
-      override = Configuration.get(:override)
-
-      expect(override.csp.directive_value(:default_src)).not_to be(default.csp.directive_value(:default_src))
-    end
-
-    it "allows you to override an override" do
-      Configuration.override(:override) do |config|
-        config.csp = { default_src: %w('self'), script_src: %w('self')}
-      end
-
-      Configuration.override(:second_override, :override) do |config|
-        config.csp = config.csp.merge(script_src: %w(example.org))
-      end
-
-      original_override = Configuration.get(:override)
-      expect(original_override.csp.to_h).to eq(default_src: %w('self'), script_src: %w('self'))
-      override_config = Configuration.get(:second_override)
-      expect(override_config.csp.to_h).to eq(default_src: %w('self'), script_src: %w('self' example.org))
+      expect(Configuration.overrides(:test_override)).to_not be_nil
     end
 
     it "deprecates the secure_cookies configuration" do

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -3,6 +3,10 @@ require "spec_helper"
 
 module SecureHeaders
   describe PolicyManagement do
+    before(:each) do
+      reset_config
+    end
+
     let (:default_opts) do
       {
         default_src: %w(https:),
@@ -164,7 +168,7 @@ module SecureHeaders
             script_src: %w('self'),
           }
         end
-        combined_config = ContentSecurityPolicy.combine_policies(Configuration.get.csp.to_h, style_src: %w(anothercdn.com))
+        combined_config = ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, style_src: %w(anothercdn.com))
         csp = ContentSecurityPolicy.new(combined_config)
         expect(csp.name).to eq(ContentSecurityPolicyConfig::HEADER_NAME)
         expect(csp.value).to eq("default-src https:; script-src 'self'; style-src https: anothercdn.com")
@@ -179,7 +183,7 @@ module SecureHeaders
           }.freeze
         end
         report_uri = "https://report-uri.io/asdf"
-        combined_config = ContentSecurityPolicy.combine_policies(Configuration.get.csp.to_h, report_uri: [report_uri])
+        combined_config = ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, report_uri: [report_uri])
         csp = ContentSecurityPolicy.new(combined_config, USER_AGENTS[:firefox])
         expect(csp.value).to include("report-uri #{report_uri}")
       end
@@ -195,7 +199,7 @@ module SecureHeaders
         non_default_source_additions = ContentSecurityPolicy::NON_FETCH_SOURCES.each_with_object({}) do |directive, hash|
           hash[directive] = %w("http://example.org)
         end
-        combined_config = ContentSecurityPolicy.combine_policies(Configuration.get.csp.to_h, non_default_source_additions)
+        combined_config = ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, non_default_source_additions)
 
         ContentSecurityPolicy::NON_FETCH_SOURCES.each do |directive|
           expect(combined_config[directive]).to eq(%w("http://example.org))
@@ -210,7 +214,7 @@ module SecureHeaders
             report_only: false
           }
         end
-        combined_config = ContentSecurityPolicy.combine_policies(Configuration.get.csp.to_h, report_only: true)
+        combined_config = ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, report_only: true)
         csp = ContentSecurityPolicy.new(combined_config, USER_AGENTS[:firefox])
         expect(csp.name).to eq(ContentSecurityPolicyReportOnlyConfig::HEADER_NAME)
       end
@@ -223,7 +227,7 @@ module SecureHeaders
             block_all_mixed_content: false
           }
         end
-        combined_config = ContentSecurityPolicy.combine_policies(Configuration.get.csp.to_h, block_all_mixed_content: true)
+        combined_config = ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, block_all_mixed_content: true)
         csp = ContentSecurityPolicy.new(combined_config)
         expect(csp.value).to eq("default-src https:; block-all-mixed-content; script-src 'self'")
       end
@@ -233,7 +237,7 @@ module SecureHeaders
           config.csp = OPT_OUT
         end
         expect do
-          ContentSecurityPolicy.combine_policies(Configuration.get.csp.to_h, script_src: %w(anothercdn.com))
+          ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, script_src: %w(anothercdn.com))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
     end

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -5,6 +5,7 @@ module SecureHeaders
   describe PolicyManagement do
     before(:each) do
       reset_config
+      Configuration.default
     end
 
     let (:default_opts) do
@@ -161,6 +162,9 @@ module SecureHeaders
     end
 
     describe "#combine_policies" do
+      before(:each) do
+        reset_config
+      end
       it "combines the default-src value with the override if the directive was unconfigured" do
         Configuration.default do |config|
           config.csp = {
@@ -168,7 +172,8 @@ module SecureHeaders
             script_src: %w('self'),
           }
         end
-        combined_config = ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, style_src: %w(anothercdn.com))
+        default_policy = Configuration.send(:default_config)
+        combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, style_src: %w(anothercdn.com))
         csp = ContentSecurityPolicy.new(combined_config)
         expect(csp.name).to eq(ContentSecurityPolicyConfig::HEADER_NAME)
         expect(csp.value).to eq("default-src https:; script-src 'self'; style-src https: anothercdn.com")
@@ -183,7 +188,8 @@ module SecureHeaders
           }.freeze
         end
         report_uri = "https://report-uri.io/asdf"
-        combined_config = ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, report_uri: [report_uri])
+        default_policy = Configuration.send(:default_config)
+        combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, report_uri: [report_uri])
         csp = ContentSecurityPolicy.new(combined_config, USER_AGENTS[:firefox])
         expect(csp.value).to include("report-uri #{report_uri}")
       end
@@ -199,7 +205,8 @@ module SecureHeaders
         non_default_source_additions = ContentSecurityPolicy::NON_FETCH_SOURCES.each_with_object({}) do |directive, hash|
           hash[directive] = %w("http://example.org)
         end
-        combined_config = ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, non_default_source_additions)
+        default_policy = Configuration.send(:default_config)
+        combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, non_default_source_additions)
 
         ContentSecurityPolicy::NON_FETCH_SOURCES.each do |directive|
           expect(combined_config[directive]).to eq(%w("http://example.org))
@@ -214,7 +221,8 @@ module SecureHeaders
             report_only: false
           }
         end
-        combined_config = ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, report_only: true)
+        default_policy = Configuration.send(:default_config)
+        combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, report_only: true)
         csp = ContentSecurityPolicy.new(combined_config, USER_AGENTS[:firefox])
         expect(csp.name).to eq(ContentSecurityPolicyReportOnlyConfig::HEADER_NAME)
       end
@@ -227,7 +235,8 @@ module SecureHeaders
             block_all_mixed_content: false
           }
         end
-        combined_config = ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, block_all_mixed_content: true)
+        default_policy = Configuration.send(:default_config)
+        combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, block_all_mixed_content: true)
         csp = ContentSecurityPolicy.new(combined_config)
         expect(csp.value).to eq("default-src https:; block-all-mixed-content; script-src 'self'")
       end
@@ -236,8 +245,9 @@ module SecureHeaders
         Configuration.default do |config|
           config.csp = OPT_OUT
         end
+        default_policy = Configuration.send(:default_config)
         expect do
-          ContentSecurityPolicy.combine_policies(Configuration.default.csp.to_h, script_src: %w(anothercdn.com))
+          ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, script_src: %w(anothercdn.com))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
     end

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -172,7 +172,7 @@ module SecureHeaders
             script_src: %w('self'),
           }
         end
-        default_policy = Configuration.send(:default_config)
+        default_policy = Configuration.dup
         combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, style_src: %w(anothercdn.com))
         csp = ContentSecurityPolicy.new(combined_config)
         expect(csp.name).to eq(ContentSecurityPolicyConfig::HEADER_NAME)
@@ -188,7 +188,7 @@ module SecureHeaders
           }.freeze
         end
         report_uri = "https://report-uri.io/asdf"
-        default_policy = Configuration.send(:default_config)
+        default_policy = Configuration.dup
         combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, report_uri: [report_uri])
         csp = ContentSecurityPolicy.new(combined_config, USER_AGENTS[:firefox])
         expect(csp.value).to include("report-uri #{report_uri}")
@@ -205,7 +205,7 @@ module SecureHeaders
         non_default_source_additions = ContentSecurityPolicy::NON_FETCH_SOURCES.each_with_object({}) do |directive, hash|
           hash[directive] = %w("http://example.org)
         end
-        default_policy = Configuration.send(:default_config)
+        default_policy = Configuration.dup
         combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, non_default_source_additions)
 
         ContentSecurityPolicy::NON_FETCH_SOURCES.each do |directive|
@@ -221,7 +221,7 @@ module SecureHeaders
             report_only: false
           }
         end
-        default_policy = Configuration.send(:default_config)
+        default_policy = Configuration.dup
         combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, report_only: true)
         csp = ContentSecurityPolicy.new(combined_config, USER_AGENTS[:firefox])
         expect(csp.name).to eq(ContentSecurityPolicyReportOnlyConfig::HEADER_NAME)
@@ -235,7 +235,7 @@ module SecureHeaders
             block_all_mixed_content: false
           }
         end
-        default_policy = Configuration.send(:default_config)
+        default_policy = Configuration.dup
         combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, block_all_mixed_content: true)
         csp = ContentSecurityPolicy.new(combined_config)
         expect(csp.value).to eq("default-src https:; block-all-mixed-content; script-src 'self'")
@@ -245,7 +245,7 @@ module SecureHeaders
         Configuration.default do |config|
           config.csp = OPT_OUT
         end
-        default_policy = Configuration.send(:default_config)
+        default_policy = Configuration.dup
         expect do
           ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, script_src: %w(anothercdn.com))
         end.to raise_error(ContentSecurityPolicyConfigError)

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -18,7 +18,7 @@ module SecureHeaders
         # (pulled from README)
         config = {
           # "meta" values. these will shape the header, but the values are not included in the header.
-          report_only:  true,     # default: false
+          report_only:  false,
           preserve_schemes: true, # default: false. Schemes are removed from host sources to save bytes and discourage mixed content.
 
           # directive values: these values will directly translate into source directives
@@ -140,6 +140,18 @@ module SecureHeaders
       it "accepts anything of the form type/subtype as a plugin-type value " do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(plugin_types: ["application/pdf"])))
+        end.to_not raise_error
+      end
+
+      it "doesn't allow report_only to be set in a non-report-only config" do
+        expect do
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(report_only: true)))
+        end.to raise_error(ContentSecurityPolicyConfigError)
+      end
+
+      it "allows report_only to be set in a report-only config" do
+        expect do
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyReportOnlyConfig.new(default_opts.merge(report_only: true)))
         end.to_not raise_error
       end
     end

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -11,10 +11,12 @@ module SecureHeaders
 
     before(:each) do
       reset_config
+      Configuration.default
     end
 
     it "warns if the hpkp report-uri host is the same as the current host" do
       report_host = "report-uri.io"
+      reset_config
       Configuration.default do |config|
         config.hpkp = {
           max_age: 10000000,
@@ -54,6 +56,9 @@ module SecureHeaders
     end
 
     context "cookies" do
+      before(:each) do
+        reset_config
+      end
       context "cookies should be flagged" do
         it "flags cookies as secure" do
           Configuration.default { |config| config.cookies = {secure: true, httponly: OPT_OUT, samesite: OPT_OUT} }
@@ -85,6 +90,9 @@ module SecureHeaders
     end
 
     context "cookies" do
+      before(:each) do
+        reset_config
+      end
       it "flags cookies from configuration" do
         Configuration.default { |config| config.cookies = { secure: true, httponly: true, samesite: { lax: true} } }
         request = Rack::Request.new("HTTPS" => "on")

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -11,7 +11,6 @@ module SecureHeaders
 
     before(:each) do
       reset_config
-      Configuration.default
     end
 
     it "warns if the hpkp report-uri host is the same as the current host" do

--- a/spec/lib/secure_headers/middleware_spec.rb
+++ b/spec/lib/secure_headers/middleware_spec.rb
@@ -50,7 +50,6 @@ module SecureHeaders
       end
       request = Rack::Request.new({})
       SecureHeaders.use_secure_headers_override(request, "my_custom_config")
-      expect(request.env[SECURE_HEADERS_CONFIG]).to be(Configuration.get("my_custom_config"))
       _, env = middleware.call request.env
       expect(env[ContentSecurityPolicyConfig::HEADER_NAME]).to match("example.org")
     end
@@ -66,7 +65,7 @@ module SecureHeaders
       end
 
       it "allows opting out of cookie protection with OPT_OUT alone" do
-        Configuration.default { |config| config.cookies = OPT_OUT}
+        Configuration.default { |config| config.cookies = OPT_OUT }
 
         # do NOT make this request https. non-https requests modify a config,
         # causing an exception when operating on OPT_OUT. This ensures we don't

--- a/spec/lib/secure_headers/view_helpers_spec.rb
+++ b/spec/lib/secure_headers/view_helpers_spec.rb
@@ -105,6 +105,7 @@ module SecureHeaders
     let(:filename) { "app/views/asdfs/index.html.erb" }
 
     before(:all) do
+      reset_config
       Configuration.default do |config|
         config.csp = {
           default_src: %w('self'),

--- a/spec/lib/secure_headers/view_helpers_spec.rb
+++ b/spec/lib/secure_headers/view_helpers_spec.rb
@@ -67,7 +67,7 @@ TEMPLATE
     end
 
     if options.is_a?(Hash)
-      options = options.map {|k, v| " #{k}=#{v}"}
+      options = options.map { |k, v| " #{k}=#{v}" }
     end
     "<#{type}#{options}>#{content}</#{type}>"
   end

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -17,7 +17,7 @@ module SecureHeaders
 
     it "raises a NotYetConfiguredError if trying to opt-out of unconfigured headers" do
       expect do
-        SecureHeaders.opt_out_of_header(request, ContentSecurityPolicyConfig::CONFIG_KEY)
+        SecureHeaders.opt_out_of_header(request, :csp)
       end.to raise_error(Configuration::NotYetConfiguredError)
     end
 
@@ -34,9 +34,9 @@ module SecureHeaders
           config.csp = { default_src: %w('self'), script_src: %w('self')}
           config.csp_report_only = config.csp
         end
-        SecureHeaders.opt_out_of_header(request, ContentSecurityPolicyConfig::CONFIG_KEY)
-        SecureHeaders.opt_out_of_header(request, ContentSecurityPolicyReportOnlyConfig::CONFIG_KEY)
-        SecureHeaders.opt_out_of_header(request, XContentTypeOptions::CONFIG_KEY)
+        SecureHeaders.opt_out_of_header(request, :csp)
+        SecureHeaders.opt_out_of_header(request, :csp_report_only)
+        SecureHeaders.opt_out_of_header(request, :x_content_type_options)
         hash = SecureHeaders.header_hash_for(request)
         expect(hash["Content-Security-Policy-Report-Only"]).to be_nil
         expect(hash["Content-Security-Policy"]).to be_nil

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -131,7 +131,7 @@ module SecureHeaders
         firefox_request = Rack::Request.new(request.env.merge("HTTP_USER_AGENT" => USER_AGENTS[:firefox]))
 
         # append an unsupported directive
-        SecureHeaders.override_content_security_policy_directives(firefox_request, {plugin_types: %w(flash)})
+        SecureHeaders.override_content_security_policy_directives(firefox_request, {plugin_types: %w(application/pdf)})
         # append a supported directive
         SecureHeaders.override_content_security_policy_directives(firefox_request, {script_src: %w('self')})
 
@@ -337,7 +337,7 @@ module SecureHeaders
                 report_only: true
               }
             end
-          }.to raise_error(ArgumentError)
+          }.to raise_error(ContentSecurityPolicyConfigError)
         end
 
         it "Raises an error if csp_report_only is used with `report_only: false`" do

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -9,18 +9,6 @@ module SecureHeaders
 
     let(:request) { Rack::Request.new("HTTP_X_FORWARDED_SSL" => "on") }
 
-    it "raises a NotYetConfiguredError if default has not been set" do
-      expect do
-        SecureHeaders.header_hash_for(request)
-      end.to raise_error(Configuration::NotYetConfiguredError)
-    end
-
-    it "raises a NotYetConfiguredError if trying to opt-out of unconfigured headers" do
-      expect do
-        SecureHeaders.opt_out_of_header(request, :csp)
-      end.to raise_error(Configuration::NotYetConfiguredError)
-    end
-
     it "raises and ArgumentError when referencing an override that has not been set" do
       expect do
         Configuration.default
@@ -364,6 +352,7 @@ module SecureHeaders
           end
 
           it "sets identical values when the configs are the same" do
+            reset_config
             Configuration.default do |config|
               config.csp = {
                 default_src: %w('self'),
@@ -381,6 +370,7 @@ module SecureHeaders
           end
 
           it "sets different headers when the configs are different" do
+            reset_config
             Configuration.default do |config|
               config.csp = {
                 default_src: %w('self'),
@@ -395,6 +385,7 @@ module SecureHeaders
           end
 
           it "allows you to opt-out of enforced CSP" do
+            reset_config
             Configuration.default do |config|
               config.csp = SecureHeaders::OPT_OUT
               config.csp_report_only = {
@@ -452,6 +443,7 @@ module SecureHeaders
 
           context "when inferring which config to modify" do
             it "updates the enforced header when configured" do
+              reset_config
               Configuration.default do |config|
                 config.csp = {
                   default_src: %w('self'),
@@ -466,6 +458,7 @@ module SecureHeaders
             end
 
             it "updates the report only header when configured" do
+              reset_config
               Configuration.default do |config|
                 config.csp = OPT_OUT
                 config.csp_report_only = {
@@ -481,6 +474,7 @@ module SecureHeaders
             end
 
             it "updates both headers if both are configured" do
+              reset_config
               Configuration.default do |config|
                 config.csp = {
                   default_src: %w(enforced.com),

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -21,6 +21,13 @@ module SecureHeaders
       end.to raise_error(Configuration::NotYetConfiguredError)
     end
 
+    it "raises a AlreadyConfiguredError if trying to configure and default has already been set " do
+      Configuration.default
+      expect do
+        Configuration.default
+      end.to raise_error(Configuration::AlreadyConfiguredError)
+    end
+
     it "raises and ArgumentError when referencing an override that has not been set" do
       expect do
         Configuration.default

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -391,7 +391,7 @@ module SecureHeaders
 
             hash = SecureHeaders.header_hash_for(request)
             expect(hash["Content-Security-Policy"]).to eq("default-src 'self'; script-src 'self'")
-            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src 'self' foo.com")
+            expect(hash["Content-Security-Policy-Report-Only"]).to eq("default-src 'self'; script-src foo.com")
           end
 
           it "allows you to opt-out of enforced CSP" do

--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -9,6 +9,18 @@ module SecureHeaders
 
     let(:request) { Rack::Request.new("HTTP_X_FORWARDED_SSL" => "on") }
 
+    it "raises a NotYetConfiguredError if default has not been set" do
+      expect do
+        SecureHeaders.header_hash_for(request)
+      end.to raise_error(Configuration::NotYetConfiguredError)
+    end
+
+    it "raises a NotYetConfiguredError if trying to opt-out of unconfigured headers" do
+      expect do
+        SecureHeaders.opt_out_of_header(request, :csp)
+      end.to raise_error(Configuration::NotYetConfiguredError)
+    end
+
     it "raises and ArgumentError when referencing an override that has not been set" do
       expect do
         Configuration.default

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,7 @@ module SecureHeaders
   class Configuration
     class << self
       def clear_default_config
-        @default_config = nil
+        remove_instance_variable(:@default_config) if defined?(@default_config)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ USER_AGENTS = {
 
 def expect_default_values(hash)
   expect(hash[SecureHeaders::ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline'")
+  expect(hash[SecureHeaders::ContentSecurityPolicyReportOnlyConfig::HEADER_NAME]).to be_nil
   expect(hash[SecureHeaders::XFrameOptions::HEADER_NAME]).to eq(SecureHeaders::XFrameOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::XDownloadOptions::HEADER_NAME]).to eq(SecureHeaders::XDownloadOptions::DEFAULT_VALUE)
   expect(hash[SecureHeaders::StrictTransportSecurity::HEADER_NAME]).to eq(SecureHeaders::StrictTransportSecurity::DEFAULT_VALUE)
@@ -34,6 +35,9 @@ def expect_default_values(hash)
   expect(hash[SecureHeaders::XPermittedCrossDomainPolicies::HEADER_NAME]).to eq(SecureHeaders::XPermittedCrossDomainPolicies::DEFAULT_VALUE)
   expect(hash[SecureHeaders::ReferrerPolicy::HEADER_NAME]).to be_nil
   expect(hash[SecureHeaders::ExpectCertificateTransparency::HEADER_NAME]).to be_nil
+  expect(hash[SecureHeaders::ClearSiteData::HEADER_NAME]).to be_nil
+  expect(hash[SecureHeaders::ExpectCertificateTransparency::HEADER_NAME]).to be_nil
+  expect(hash[SecureHeaders::PublicKeyPins::HEADER_NAME]).to be_nil
 end
 
 module SecureHeaders

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,13 +43,13 @@ end
 module SecureHeaders
   class Configuration
     class << self
-      def clear_configurations
-        @configurations = nil
+      def clear_default_config
+        @default_config = nil
       end
     end
   end
 end
 
 def reset_config
-  SecureHeaders::Configuration.clear_configurations
+  SecureHeaders::Configuration.clear_default_config
 end


### PR DESCRIPTION
:warning: Work in progress ⚠️ 

This PR is very likely not yet ready for a full review. But, I wanted to push up the work in progress to get a sense of whether the direction of it is palatable, since I am introducing some relatively foundational changes that will definitely break some existing uses. 

#380 outlines a bug related to the current implementation of named overrides. There is an underlying assumption that named override is more or less a "fork" of a parent configuration. The parent configuration, at the point the override is defined, is duplicated and then the changes in the override are applied. The resulting configuration is statically stored in a class instance variable and can be retrieved when it is requested with `Configuration.get(:named_override`). Unfortunately, this model is directly at odds with how configurations work at runtime. Imagine the following scenario:

* Request is using the default config
* At runtime we append on another `script-src`
* At runtime we apply an override

Currently, the above scenario results in the appended `script-src` from not showing up. The reason is that, when we call the override, it applies the config that was generated when the override was defined. That config is simply a copy of the original default config with the overridden directives applied. So, the dynamic changes made to the default config are lost. 

In order to fix this we, unfortunately, need to redefine the entire notion of an override. Most callers would assume that an override will override the "current configuration" at runtime. As a result, we can't statically computer the override at the point it is defined. Instead, we need to treat overrides more like how we treat named appends. We store the provided block for an override in a hash that maps the name to the `Proc`. Then, when the override is requested, we `instance_eval` the `Proc` with the current configuration for the request. 

Also, during this PR it became evident that trying to cache the generated configs was incredibly complex and prone to error. This PR removes the caching and just computes the headers on demand for each request. We already hit this case a fair bit if one ever used per-request overrides anyway, since the cached values would get invalidated depending on which code path you went through on a given request. The computation overhead of making a header is relatively low and we don't expect it to be a concern. If there is a concern we could optimize the base case and only precompute the default config. But, if any changes are applied, then the precomputation is lost. As I'm typing this it sounds like that could be a nice win, since so few folks probably use dynamic policies. Thoughts?

fixes #380

## All PRs:

* [x] Has tests
* [ ] Documentation updated
