### PR TITLE
Avoid calling content_security_policy_nonce internally

### DIFF
--- a/lib/secure_headers/view_helper.rb
+++ b/lib/secure_headers/view_helper.rb
@@ -19,7 +19,7 @@ module SecureHeaders
     #
     # Returns an html-safe link tag with the nonce attribute.
     def nonced_stylesheet_link_tag(*args, &block)
-      opts = extract_options(args).merge(nonce: content_security_policy_nonce(:style))
+      opts = extract_options(args).merge(nonce: _content_security_policy_nonce(:style))
 
       stylesheet_link_tag(*args, opts, &block)
     end
@@ -37,7 +37,7 @@ module SecureHeaders
     #
     # Returns an html-safe script tag with the nonce attribute.
     def nonced_javascript_include_tag(*args, &block)
-      opts = extract_options(args).merge(nonce: content_security_policy_nonce(:script))
+      opts = extract_options(args).merge(nonce: _content_security_policy_nonce(:script))
 
       javascript_include_tag(*args, opts, &block)
     end
@@ -47,7 +47,7 @@ module SecureHeaders
     #
     # Returns an html-safe script tag with the nonce attribute.
     def nonced_javascript_pack_tag(*args, &block)
-      opts = extract_options(args).merge(nonce: content_security_policy_nonce(:script))
+      opts = extract_options(args).merge(nonce: _content_security_policy_nonce(:script))
 
       javascript_pack_tag(*args, opts, &block)
     end
@@ -57,7 +57,7 @@ module SecureHeaders
     #
     # Returns an html-safe link tag with the nonce attribute.
     def nonced_stylesheet_pack_tag(*args, &block)
-      opts = extract_options(args).merge(nonce: content_security_policy_nonce(:style))
+      opts = extract_options(args).merge(nonce: _content_security_policy_nonce(:style))
 
       stylesheet_pack_tag(*args, opts, &block)
     end
@@ -66,7 +66,7 @@ module SecureHeaders
     # Instructs secure_headers to append a nonce to style/script-src directives.
     #
     # Returns a non-html-safe nonce value.
-    def content_security_policy_nonce(type)
+    def _content_security_policy_nonce(type)
       case type
       when :script
         SecureHeaders.content_security_policy_script_nonce(@_request)
@@ -74,13 +74,14 @@ module SecureHeaders
         SecureHeaders.content_security_policy_style_nonce(@_request)
       end
     end
+    alias_method :content_security_policy_nonce, :_content_security_policy_nonce
 
     def content_security_policy_script_nonce
-      content_security_policy_nonce(:script)
+      _content_security_policy_nonce(:script)
     end
 
     def content_security_policy_style_nonce
-      content_security_policy_nonce(:style)
+      _content_security_policy_nonce(:style)
     end
 
     ##
@@ -152,7 +153,7 @@ module SecureHeaders
       else
         content_or_options.html_safe # :'(
       end
-      content_tag type, content, options.merge(nonce: content_security_policy_nonce(type))
+      content_tag type, content, options.merge(nonce: _content_security_policy_nonce(type))
     end
 
     def extract_options(args)


### PR DESCRIPTION
Rails 5.2 adds support for configuring a Content-Security-Policy header, including adding nonces to tags produced by the `javascript_tag` helper.

Unfortunately, Rails and this gem now both define a helper named `content_security_policy_nonce`:

https://github.com/rails/rails/blob/v5.2.0.rc2/actionpack/lib/action_controller/metal/content_security_policy.rb#L44
https://github.com/twitter/secureheaders/blob/v5.0.5/lib/secure_headers/view_helper.rb#L69

The Rails helper wins over the Secure Headers one, and helpers like `nonced_javascript_tag` currently raise this error on Rails 5.2:

    ArgumentError: wrong number of arguments (given 1, expected 0)

By using a method with a different name internally, we avoid clashing with the Rails implementation, and `nonced_javascript_tag` works again.