### PR TITLE
Remove non-lowercase headers in Rails default configuration (fixes #541)

### DIFF
--- a/lib/secure_headers/railtie.rb
+++ b/lib/secure_headers/railtie.rb
@@ -22,9 +22,12 @@ if defined?(Rails::Railtie)
         ActiveSupport.on_load(:action_controller) do
           include SecureHeaders
 
-          unless Rails.application.config.action_dispatch.default_headers.nil?
-            conflicting_headers.each do |header|
-              Rails.application.config.action_dispatch.default_headers.delete(header)
+          default_headers = Rails.application.config.action_dispatch.default_headers
+          unless default_headers.nil?
+            default_headers.each_key do |header|
+              if conflicting_headers.include?(header.downcase)
+                default_headers.delete(header)
+              end
             end
           end
         end


### PR DESCRIPTION
This implements the solution proposed in https://github.com/github/secure_headers/issues/541

The full details of the issue can are described in that ticket.  To summarize:

While secure_headers now uses lowercase headers (as required by Rack 3+), the Rails default configuration still defines non-lowercase headers.  As a result, our Railtie will not remove those conflicting headers.

This change ensures that we're accounting for both lowercase and non-lowercase default headers in Rails (for current Rails defaults and future defaults).

## All PRs:

* [ ] Has tests
* [x] Documentation updated

## Adding a new header

Generally, adding a new header is always OK.

* Is the header supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the header?
* Where does the specification live?

## Adding a new CSP directive

* Is the directive supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the directive?

